### PR TITLE
Added ssh_private_ip config to enable use of VM private IP addresses

### DIFF
--- a/packer/builder/azure/config.go
+++ b/packer/builder/azure/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	tmpServiceName   string
 	tmpContainerName string
 	userImageName    string
+        SSHPrivateIp     bool   `mapstructure:"ssh_private_ip"`
 
 	Comm communicator.Config `mapstructure:",squash"`
 

--- a/packer/builder/azure/config_test.go
+++ b/packer/builder/azure/config_test.go
@@ -21,6 +21,7 @@ func getDefaultTestConfig(publishSettingsFileName string) map[string]interface{}
 		"location":                  "Central US",
 		"instance_size":             "Large",
 		"user_image_label":          "boo",
+                "use_private_ip":            false,
 	}
 }
 


### PR DESCRIPTION
When using an Azure VNet, public endpoints cannot be used to reach virtual machines.

This commit adds an ssh_private_ip config option which accepts a boolean value.  When true, the private IP address of Azure VMs will be used when executing remote provisioning commands, instead of the public endpoint IP.
