### PR TITLE
Fix regression of DisableSSHPasswordAuthentication

### DIFF
--- a/config_examples/packer-azure_CentOS.json
+++ b/config_examples/packer-azure_CentOS.json
@@ -15,7 +15,8 @@
       "os_image_label": "OpenLogic 7.1",
       "location": "Central US",
       "instance_size": "Small",
-      "user_image_label": "PackerMade_OpenLogicImage"
+      "user_image_label": "PackerMade_OpenLogicImage",
+      "ssh_pty": "true"
     }
   ],
   "provisioners": [


### PR DESCRIPTION
Issue #62 regressed when adopting the Azure SDK for Go, this re-fixes this issue.