### PR TITLE
New parameter os_image_name

### DIFF
--- a/packer/builder/azure/smapi/config.go
+++ b/packer/builder/azure/smapi/config.go
@@ -31,6 +31,7 @@ type Config struct {
 
 	OSType                string `mapstructure:"os_type"`
 	OSImageLabel          string `mapstructure:"os_image_label"`
+	OSImageName           string `mapstructure:"os_image_name"`
 	RemoteSourceImageLink string `mapstructure:"remote_source_image_link"`
 	ResizeOSVhdGB         *int   `mapstructure:"resize_os_vhd_gb"`
 
@@ -112,12 +113,19 @@ func newConfig(raws ...interface{}) (*Config, []string, error) {
 			fmt.Errorf("os_type is not valid, must be one of: %s, %s", constants.Target_Windows, constants.Target_Linux))
 	}
 
-	if c.RemoteSourceImageLink == "" && c.OSImageLabel == "" {
-		errs = packer.MultiErrorAppend(errs, fmt.Errorf("os_image_label or remote_source_image_link must be specified"))
+	count := 0
+	if c.RemoteSourceImageLink != "" {
+		count += 1
+	}
+	if c.OSImageLabel != "" {
+		count += 1
+	}
+	if c.OSImageName != "" {
+		count += 1
 	}
 
-	if c.RemoteSourceImageLink != "" && c.OSImageLabel != "" {
-		errs = packer.MultiErrorAppend(errs, fmt.Errorf("os_image_label and remote_source_image_link cannot both be specified"))
+	if count != 1 {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("One source and only one among os_image_label, os_image_label or remote_source_image_link has to be specified"))
 	}
 
 	if c.Location == "" {

--- a/packer/builder/azure/smapi/step_validate.go
+++ b/packer/builder/azure/smapi/step_validate.go
@@ -74,7 +74,7 @@ func (*StepValidate) Run(state multistep.StateBag) multistep.StepAction {
 				return err
 			}
 
-			if osImage, found := FindOSImage(imageList.OSImages, config.OSImageLabel, config.Location); found {
+			if osImage, found := FindOSImage(imageList.OSImages, config.OSImageName, config.OSImageLabel, config.Location); found {
 				vmutils.ConfigureDeploymentFromPlatformImage(&role, osImage.Name, destinationVhd, "")
 				ui.Message(fmt.Sprintf("Image source is OS image %q", osImage.Name))
 				if osImage.OS != config.OSType {
@@ -97,7 +97,7 @@ func (*StepValidate) Run(state multistep.StateBag) multistep.StepAction {
 					return err
 				}
 
-				if vmImage, found := FindVmImage(imageList.VMImages, "", config.OSImageLabel); found {
+				if vmImage, found := FindVmImage(imageList.VMImages, config.OSImageName, config.OSImageLabel); found {
 					if config.ResizeOSVhdGB != nil {
 						return fmt.Errorf("Packer cannot resize VM images")
 					}


### PR DESCRIPTION
The proposed code adds a parameter os_image_name to be used instead of os_image_label. 
It allows to precise the name of the source image either : 
- as listed in "azure vm image list", ie the hermetic [32chars id]__[human_readble_name]
- or only the last part of the name [human_readble_name]
depending on what you prefer to copy paste or read. 

For instance : 
```
"os_image_name": "Ubuntu-14_04_3-LTS-amd64-server-20150805-en-us-30GB"
"os_image_name": "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_3-LTS-amd64-server-20150805-en-us-30GB"
```

It should solve the issue #108 as the user can more easily find the name of the OS he is looking for, and implements the #131 . 