### PR TITLE
Define custom adminUsername ARM template parameter

### DIFF
--- a/config_examples/packer-azure_CentOS.json
+++ b/config_examples/packer-azure_CentOS.json
@@ -15,6 +15,7 @@
       "os_image_label": "OpenLogic 7.1",
       "location": "Central US",
       "instance_size": "Small",
+      "username": "centos",
       "user_image_label": "PackerMade_OpenLogicImage",
       "ssh_pty": "true"
     }


### PR DESCRIPTION
See the parameter in ARM template: [adminUsername](https://github.com/Azure/packer-azure/blob/master/packer/builder/azure/arm/template.go#L12)
Which defaults to [packer](https://github.com/Azure/packer-azure/blob/master/packer/builder/azure/arm/config.go#L21)
But can be customized by: [username](https://github.com/Azure/packer-azure/blob/master/packer/builder/azure/arm/config.go#L50)

Fixes: #196