### PR TITLE
Move OS Generalize to Provisioner

### DIFF
--- a/config_examples/arm/CentOS_7.1.json
+++ b/config_examples/arm/CentOS_7.1.json
@@ -6,7 +6,10 @@
         "sid": "your_subscription_id",
 
         "rgn": "your_resource_group",
-        "sa": "your_storage_account"
+        "sa": "your_storage_account",
+
+        "ssh_user": "centos",
+        "ssh_pass": null
     },
     "builders": [
         {
@@ -23,6 +26,9 @@
             "capture_container_name": "images",
             "capture_name_prefix": "packer",
 
+            "ssh_username": "{{user `ssh_user`}}",
+            "ssh_password": "{{user `ssh_pass`}}",
+
             "image_publisher": "OpenLogic",
             "image_offer": "CentOS",
             "image_sku": "7.1",
@@ -34,12 +40,14 @@
     ],
     "provisioners": [
         {
-            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+            "execute_command": "echo '{{user `ssh_pass`}}' | {{ .Vars }} sudo -S -E sh '{{ .Path }}'",
             "inline": [
-                "echo '!! Hello CentOS !!'"
+                "yum update -y",
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
-            "type": "shell"
+            "type": "shell",
+            "skip_clean": true
         }
     ]
 }

--- a/config_examples/arm/OpenSuSE_13.2.json
+++ b/config_examples/arm/OpenSuSE_13.2.json
@@ -6,7 +6,10 @@
         "sid": "your_subscription_id",
 
         "rgn": "your_resource_group",
-        "sa": "your_storage_account"
+        "sa": "your_storage_account",
+
+        "ssh_user": "packer",
+        "ssh_pass": null
     },
     "builders": [
         {
@@ -23,6 +26,9 @@
             "capture_container_name": "images",
             "capture_name_prefix": "packer",
 
+            "ssh_username": "{{user `ssh_user`}}",
+            "ssh_password": "{{user `ssh_pass`}}",
+
             "image_publisher": "SUSE",
             "image_offer": "openSUSE",
             "image_sku": "13.2",
@@ -35,8 +41,11 @@
     ],
     "provisioners": [
         {
+            "execute_command": "echo '{{user `ssh_pass`}}' | {{ .Vars }} sudo -S -E sh '{{ .Path }}'",
             "inline": [
-                "echo '!! Hello OpenSuSE !!'"
+                "zypper update -y",
+
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
             "type": "shell"

--- a/config_examples/arm/README.md
+++ b/config_examples/arm/README.md
@@ -26,15 +26,47 @@ packer build^
   c:\packer\ubuntu_14.04.3-LTS.json
 ```
 
-All templates with the exception of Ubuntu set the configuration
-parameter
+All sample templates with the exception of Ubuntu set the
+configuration parameter
 [ssh_pty](https://www.packer.io/docs/templates/communicator.html) to
-true.  These OSs require a pty when executing ssh commands, which
-generally causes **sudo** commands to fail (YMMV).  Please review the
-following issues for details.
+true.  These OSs require a pty when executing ssh commands, and
+require a password be supplied to elevate via sudo.  (The
+execute_command for these templates inject the password to sudo via
+[STDIN](https://www.packer.io/docs/provisioners/shell.html).)  The
+password **must** be supplied by the user.  A sample script for these
+templates is shown below.  Note that the *ssh_pass* parameter is now
+supplied.
 
-* [mitchellh/packer #1804](https://github.com/mitchellh/packer/issues/1804)
-* [mitchellh/packer #2420](https://github.com/mitchellh/packer/issues/2420)
-* [mitchellh/packer #2423](https://github.com/mitchellh/packer/issues/2423)
-* etc.
+```batch
+packer build^
+  -var cid="593c4dc4-9cd7-49af-9fe0-1ea5055ac1e4"^
+  -var cst="GbzJfsfrVkqL/TLfZY8TXA=="^
+  -var sid="ce323e74-56fc-4bd6-aa18-83b6dc262748"^
+  -var tid="da3847b4-8e69-40bd-a2c2-41da6982c5e2"^
+  -var rgn="My Resource Group"^
+  -var sa="mystorageaccount"^
+  -var ssh_pass="packer"^
+  c:\packer\CentOS_7.1.json
+```
 
+## UNIX OS Generalization
+
+The ARM builders executes OS generalization via a packer provisioner.
+The last command executed by a provisioner should be the following.
+
+```sh
+/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync
+```
+
+This ensures that...
+
+1. All SSH host key pairs will be deleted.
+1. Cached DHCP leases will be deleted.
+1. Nameserver configuration in /etc/resolv.conf (or where appropriate)
+   will be deleted.
+1. The user name provisioned by packer will be deleted.
+1. Root password will be disabled (as appropriate).
+
+OS Generalization used to be an explicit step in the old (SMAPI)
+builder, and was hidden from end users.  It has been made into an
+explicit step to better support the various UNIX flavors.

--- a/config_examples/arm/debian_8.json
+++ b/config_examples/arm/debian_8.json
@@ -6,7 +6,10 @@
         "sid": "your_subscription_id",
 
         "rgn": "your_resource_group",
-        "sa": "your_storage_account"
+        "sa": "your_storage_account",
+
+        "ssh_user": "packer",
+        "ssh_pass": null
     },
     "builders": [
         {
@@ -23,6 +26,9 @@
             "capture_container_name": "images",
             "capture_name_prefix": "packer",
 
+            "ssh_username": "{{user `ssh_user`}}",
+            "ssh_password": "{{user `ssh_pass`}}",
+
             "image_publisher": "credativ",
             "image_offer": "Debian",
             "image_sku": "8",
@@ -35,9 +41,12 @@
     ],
     "provisioners": [
         {
-            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+            "execute_command": "echo '{{user `ssh_pass`}}' | {{ .Vars }} sudo -S -E sh '{{ .Path }}'",
             "inline": [
-                "echo '!! Hello Debian !!'"
+                "apt-get update",
+                "apt-get upgrade -y",
+
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
             "type": "shell"

--- a/config_examples/arm/ubuntu_14.04.3-LTS.json
+++ b/config_examples/arm/ubuntu_14.04.3-LTS.json
@@ -36,8 +36,10 @@
         {
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
             "inline": [
-                "echo '!! Hello Ubuntu !!'",
-                "sudo apt-get update"
+                "apt-get update",
+                "apt-get upgrade -y",
+
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
             "type": "shell"

--- a/config_examples/packer-azure_Debian.json
+++ b/config_examples/packer-azure_Debian.json
@@ -21,9 +21,10 @@
   ],
   "provisioners": [
     {
-      "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+      "execute_command": "echo '{{user `ssh_pass`}}' | {{ .Vars }} sudo -S -E sh '{{ .Path }}'",
       "inline": [
         "apt-get update"
+        "apt-get upgrade -y"
       ],
       "inline_shebang": "/bin/sh -x",
       "type": "shell"

--- a/packer/builder/azure/arm/builder.go
+++ b/packer/builder/azure/arm/builder.go
@@ -74,9 +74,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SSHConfig: lin.SSHConfig(b.config.UserName),
 		},
 		&common.StepProvision{},
-		&lin.StepGeneralizeOS{
-			Command: "sudo /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync",
-		},
 		NewStepGetOSDisk(azureClient, ui),
 		NewStepPowerOffCompute(azureClient, ui),
 		NewStepCaptureImage(azureClient, ui),
@@ -86,7 +83,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	if b.config.PackerDebug {
 		ui.Message(fmt.Sprintf("temp admin user: '%s'", b.config.UserName))
-		ui.Message(fmt.Sprintf("temp admin password: '%s'", b.config.tmpAdminPassword))
+		ui.Message(fmt.Sprintf("temp admin password: '%s'", b.config.Password))
 	}
 
 	b.runner = b.createRunner(&steps, ui)

--- a/packer/builder/azure/arm/config_test.go
+++ b/packer/builder/azure/arm/config_test.go
@@ -43,6 +43,41 @@ func TestConfigShouldProvideReasonableDefaultValues(t *testing.T) {
 	}
 }
 
+func TestConfigShouldBeAbleToOverrideDefaultedValues(t *testing.T) {
+	builderValues := make(map[string]string)
+
+	// Populate the dictionary with all of the required values.
+	for _, v := range requiredConfigValues {
+		builderValues[v] = "--some-value--"
+	}
+
+	builderValues["ssh_password"] = "override_password"
+	builderValues["ssh_username"] = "override_username"
+	builderValues["vm_size"] = "override_vm_size"
+
+	c, _, _ := newConfig(getArmBuilderConfigurationFromMap(builderValues), getPackerConfiguration())
+
+	if c.Password != "override_password" {
+		t.Errorf("Expected 'Password' to be set to 'override_password', but found '%s'!", c.Password)
+	}
+
+	if c.Comm.SSHPassword != "override_password" {
+		t.Errorf("Expected 'c.Comm.SSHPassword' to be set to 'override_password', but found '%s'!", c.Comm.SSHPassword)
+	}
+
+	if c.UserName != "override_username" {
+		t.Errorf("Expected 'UserName' to be set to 'override_username', but found '%s'!", c.UserName)
+	}
+
+	if c.Comm.SSHUsername != "override_username" {
+		t.Errorf("Expected 'c.Comm.SSHUsername' to be set to 'override_username', but found '%s'!", c.Comm.SSHUsername)
+	}
+
+	if c.VMSize != "override_vm_size" {
+		t.Errorf("Expected 'vm_size' to be set to 'override_username', but found '%s'!", c.VMSize)
+	}
+}
+
 func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
 	c, _, _ := newConfig(getArmBuilderConfiguration(), getPackerConfiguration())
 
@@ -83,8 +118,8 @@ func TestUserShouldProvideRequiredValues(t *testing.T) {
 func TestSystemShouldDefineRuntimeValues(t *testing.T) {
 	c, _, _ := newConfig(getArmBuilderConfiguration(), getPackerConfiguration())
 
-	if c.tmpAdminPassword == "" {
-		t.Errorf("Expected tmpAdminPassword to not be empty, but it was '%s'!", c.tmpAdminPassword)
+	if c.Password == "" {
+		t.Errorf("Expected Password to not be empty, but it was '%s'!", c.Password)
 	}
 
 	if c.tmpComputeName == "" {


### PR DESCRIPTION
Clean up some of the existing templates, and make them more useful (and work).

Move the OS generalize step to the provisioner because the provisioner knows how to execute a remote command, but a Communicator does not necessarily.

Cleanup up some uses of username, ssh_username, password, ssh_password, and ensure that precedence when overriding is treated appropriately.