### PR TITLE
Handle API update to better handle OAuth.

### DIFF
--- a/packer/builder/azure/arm/builder.go
+++ b/packer/builder/azure/arm/builder.go
@@ -143,11 +143,16 @@ func (b *Builder) configureStateBag(stateBag multistep.StateBag) error {
 }
 
 func (b *Builder) createServicePrincipalToken() (*azure.ServicePrincipalToken, error) {
+	oauthConfig, err := azure.PublicCloud.OAuthConfigForTenant(b.config.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
 	spt, err := azure.NewServicePrincipalToken(
+		*oauthConfig,
 		b.config.ClientID,
 		b.config.ClientSecret,
-		b.config.TenantID,
-		azure.AzureResourceManagerScope)
+		azure.PublicCloud.ResourceManagerEndpoint)
 
 	return spt, err
 }


### PR DESCRIPTION
There was a build break because the go-autorest changed the way Service
Principal Tokens (SPT) are created.  The API is now explicit about how an
OAuth token is formulated, and the endpoints used.  The code hardcodes to
Azure's public cloud.  We are no worse than we were because we still did not
support US Government Cloud and China.  There is already a pending issue
to address this.