### PR TITLE
Support interrupting long running tasks.

### DIFF
--- a/packer/builder/azure/arm/step.go
+++ b/packer/builder/azure/arm/step.go
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package arm
+
+import (
+	"github.com/Azure/packer-azure/packer/builder/azure/common"
+	"github.com/Azure/packer-azure/packer/builder/azure/common/constants"
+	"github.com/mitchellh/multistep"
+)
+
+func processInterruptibleResult(
+	result common.InterruptibleTaskResult, sayError func(error), state multistep.StateBag) multistep.StepAction {
+	if result.IsCancelled {
+		return multistep.ActionHalt
+	}
+
+	return processStepResult(result.Err, sayError, state)
+}
+
+func processStepResult(
+	err error, sayError func(error), state multistep.StateBag) multistep.StepAction {
+
+	if err != nil {
+		state.Put(constants.Error, err)
+		sayError(err)
+
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+
+}

--- a/packer/builder/azure/arm/step_create_resource_group.go
+++ b/packer/builder/azure/arm/step_create_resource_group.go
@@ -48,14 +48,7 @@ func (s *StepCreateResourceGroup) Run(state multistep.StateBag) multistep.StepAc
 	s.say(fmt.Sprintf(" -> Location          : '%s'", location))
 
 	err := s.create(resourceGroupName, location)
-	if err != nil {
-		state.Put(constants.Error, err)
-		s.error(err)
-
-		return multistep.ActionHalt
-	}
-
-	return multistep.ActionContinue
+	return processStepResult(err, s.error, state)
 }
 
 func (*StepCreateResourceGroup) Cleanup(multistep.StateBag) {

--- a/packer/builder/azure/arm/step_delete_os_disk.go
+++ b/packer/builder/azure/arm/step_delete_os_disk.go
@@ -54,13 +54,7 @@ func (s *StepDeleteOSDisk) Run(state multistep.StateBag) multistep.StepAction {
 	var blobName = strings.Join(xs[2:], "/")
 
 	err = s.delete(storageAccountName, blobName)
-	if err != nil {
-		state.Put(constants.Error, err)
-		s.error(err)
-
-		return multistep.ActionHalt
-	}
-	return multistep.ActionContinue
+	return processStepResult(err, s.error, state)
 }
 
 func (*StepDeleteOSDisk) Cleanup(multistep.StateBag) {

--- a/packer/builder/azure/arm/step_test.go
+++ b/packer/builder/azure/arm/step_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package arm
+
+import (
+	"fmt"
+	"github.com/Azure/packer-azure/packer/builder/azure/common"
+	"github.com/Azure/packer-azure/packer/builder/azure/common/constants"
+	"github.com/mitchellh/multistep"
+	"testing"
+)
+
+func TestProcessStepResultShouldContinueForNonErrors(t *testing.T) {
+	stateBag := new(multistep.BasicStateBag)
+
+	code := processStepResult(nil, func(error) { t.Fatalf("Should not be called!") }, stateBag)
+	if _, ok := stateBag.GetOk(constants.Error); ok {
+		t.Errorf("Error was nil, but was still in the state bag.")
+	}
+
+	if code != multistep.ActionContinue {
+		t.Errorf("Expected ActionContinue(%d), but got=%d", multistep.ActionContinue, code)
+	}
+}
+
+func TestProcessStepResultShouldHaltOnError(t *testing.T) {
+	stateBag := new(multistep.BasicStateBag)
+	isSaidError := false
+
+	code := processStepResult(fmt.Errorf("boom"), func(error) { isSaidError = true }, stateBag)
+	if _, ok := stateBag.GetOk(constants.Error); !ok {
+		t.Errorf("Error was non nil, but was not in the state bag.")
+	}
+
+	if !isSaidError {
+		t.Errorf("Expected error to be said, but it was not.")
+	}
+
+	if code != multistep.ActionHalt {
+		t.Errorf("Expected ActionHalt(%d), but got=%d", multistep.ActionHalt, code)
+	}
+}
+
+func TestProcessStepResultShouldContinueOnSuccessfulTask(t *testing.T) {
+	stateBag := new(multistep.BasicStateBag)
+	result := common.InterruptibleTaskResult{
+		IsCancelled: false,
+		Err:         nil,
+	}
+
+	code := processInterruptibleResult(result, func(error) { t.Fatalf("Should not be called!") }, stateBag)
+	if _, ok := stateBag.GetOk(constants.Error); ok {
+		t.Errorf("Error was nil, but was still in the state bag.")
+	}
+
+	if code != multistep.ActionContinue {
+		t.Errorf("Expected ActionContinue(%d), but got=%d", multistep.ActionContinue, code)
+	}
+}
+
+func TestProcessStepResultShouldHaltWhenTaskIsCancelled(t *testing.T) {
+	stateBag := new(multistep.BasicStateBag)
+	result := common.InterruptibleTaskResult{
+		IsCancelled: true,
+		Err:         nil,
+	}
+
+	code := processInterruptibleResult(result, func(error) { t.Fatalf("Should not be called!") }, stateBag)
+	if _, ok := stateBag.GetOk(constants.Error); ok {
+		t.Errorf("Error was nil, but was still in the state bag.")
+	}
+
+	if code != multistep.ActionHalt {
+		t.Errorf("Expected ActionHalt(%d), but got=%d", multistep.ActionHalt, code)
+	}
+}
+
+func TestProcessStepResultShouldHaltOnTaskError(t *testing.T) {
+	stateBag := new(multistep.BasicStateBag)
+	isSaidError := false
+	result := common.InterruptibleTaskResult{
+		IsCancelled: false,
+		Err:         fmt.Errorf("boom"),
+	}
+
+	code := processInterruptibleResult(result, func(error) { isSaidError = true }, stateBag)
+	if _, ok := stateBag.GetOk(constants.Error); !ok {
+		t.Errorf("Error was *not* nil, but was not in the state bag.")
+	}
+
+	if !isSaidError {
+		t.Errorf("Expected error to be said, but it was not.")
+	}
+
+	if code != multistep.ActionHalt {
+		t.Errorf("Expected ActionHalt(%d), but got=%d", multistep.ActionHalt, code)
+	}
+}

--- a/packer/builder/azure/arm/step_validate_template.go
+++ b/packer/builder/azure/arm/step_validate_template.go
@@ -54,14 +54,7 @@ func (s *StepValidateTemplate) Run(state multistep.StateBag) multistep.StepActio
 	s.say(fmt.Sprintf(" -> DeploymentName    : '%s'", deploymentName))
 
 	err := s.validate(resourceGroupName, deploymentName, templateParameters)
-	if err != nil {
-		state.Put(constants.Error, err)
-		s.error(err)
-
-		return multistep.ActionHalt
-	}
-
-	return multistep.ActionContinue
+	return processStepResult(err, s.error, state)
 }
 
 func (*StepValidateTemplate) Cleanup(multistep.StateBag) {

--- a/packer/builder/azure/common/interruptible_task.go
+++ b/packer/builder/azure/common/interruptible_task.go
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package common
+
+import (
+	"time"
+)
+
+type InterruptibleTaskResult struct {
+	Err         error
+	IsCancelled bool
+}
+
+type InterruptibleTask struct {
+	IsCancelled func() bool
+	Task        func() error
+}
+
+func NewInterruptibleTask(isCancelled func() bool, task func() error) *InterruptibleTask {
+	return &InterruptibleTask{
+		IsCancelled: isCancelled,
+		Task:        task,
+	}
+}
+
+func StartInterruptibleTask(isCancelled func() bool, task func() error) InterruptibleTaskResult {
+	t := NewInterruptibleTask(isCancelled, task)
+	return t.Run()
+}
+
+func (s *InterruptibleTask) Run() InterruptibleTaskResult {
+	completeCh := make(chan error)
+	defer close(completeCh)
+
+	go func() {
+		err := s.Task()
+		completeCh <- err
+	}()
+
+	resultCh := make(chan InterruptibleTaskResult)
+	defer close(resultCh)
+
+	for {
+		if s.IsCancelled() {
+			return InterruptibleTaskResult{Err: nil, IsCancelled: true}
+		}
+
+		select {
+		case err := <-completeCh:
+			return InterruptibleTaskResult{Err: err, IsCancelled: false}
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}

--- a/packer/builder/azure/common/interruptible_task_test.go
+++ b/packer/builder/azure/common/interruptible_task_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package common
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestInterruptibleTaskShouldImmediatelyEndOnCancel(t *testing.T) {
+	testSubject := NewInterruptibleTask(
+		func() bool { return true },
+		func() error {
+			for {
+				time.Sleep(time.Second * 30)
+			}
+		})
+
+	result := testSubject.Run()
+	if result.IsCancelled != true {
+		t.Fatalf("Expected the task to be cancelled, but it was not.")
+	}
+}
+
+func TestInterruptibleTaskShouldRunTaskUntilCompletion(t *testing.T) {
+	var count int
+
+	testSubject := &InterruptibleTask{
+		IsCancelled: func() bool {
+			return false
+		},
+		Task: func() error {
+			for i := 0; i < 10; i++ {
+				count += 1
+			}
+
+			return nil
+		},
+	}
+
+	result := testSubject.Run()
+	if result.IsCancelled != false {
+		t.Errorf("Expected the task to *not* be cancelled, but it was.")
+	}
+
+	if count != 10 {
+		t.Errorf("Expected the task to wait for completion, but it did not.")
+	}
+
+	if result.Err != nil {
+		t.Errorf("Expected the task to return a nil error, but got=%s", result.Err)
+	}
+}
+
+func TestInterruptibleTaskShouldImmediatelyStopOnTaskError(t *testing.T) {
+	testSubject := &InterruptibleTask{
+		IsCancelled: func() bool {
+			return false
+		},
+		Task: func() error {
+			return fmt.Errorf("boom")
+		},
+	}
+
+	result := testSubject.Run()
+	if result.IsCancelled != false {
+		t.Errorf("Expected the task to *not* be cancelled, but it was.")
+	}
+
+	if result.Err == nil {
+		t.Errorf("Expected the task to return an error, but it did not.")
+	}
+}

--- a/packer/builder/azure/common/state_bag.go
+++ b/packer/builder/azure/common/state_bag.go
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package common
+
+import "github.com/mitchellh/multistep"
+
+func IsStateCancelled(stateBag multistep.StateBag) bool {
+	_, ok := stateBag.GetOk(multistep.StateCancelled)
+	return ok
+}


### PR DESCRIPTION
Fix for #141.

If a user hits Ctrl-C the user will have to wait until the step has
completed before the Ctrl-C is processed.  This change processes the
Ctrl-C within a 100ms, and immediately aborts all work.  There is no
cleanup done, and the task running in Azure is not killed.  The following
tasks are now interruptible.

 * capture image
 * delete resource group
 * deploy template
 * power off

All othere tasks run quickly enough that I did not make them
interruptible.

Small refactoring to the way errors are handled at the end of each step.