### PR TITLE
Fix case consistency and 'till'

### DIFF
--- a/packer/builder/azure/common/lin/step_create_cert.go
+++ b/packer/builder/azure/common/lin/step_create_cert.go
@@ -28,11 +28,11 @@ type StepCreateCert struct {
 func (s *StepCreateCert) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
-	ui.Say("Creating Temporary Certificate...")
+	ui.Say("Creating temporary certificate...")
 
 	err := s.createCert(state)
 	if err != nil {
-		err := fmt.Errorf("Error Creating Temporary Certificate: %s", err)
+		err := fmt.Errorf("Error creating temporary certificate: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/packer/builder/azure/smapi/step_create_vm.go
+++ b/packer/builder/azure/smapi/step_create_vm.go
@@ -23,9 +23,9 @@ func (*StepCreateVm) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	config := state.Get(constants.Config).(*Config)
 
-	errorMsg := "Error Creating Temporary Azure VM: %s"
+	errorMsg := "Error Creating temporary Azure VM: %s"
 
-	ui.Say("Creating Temporary Azure VM...")
+	ui.Say("Creating temporary Azure VM...")
 
 	role := state.Get("role").(*vm.Role)
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixed some case consistencies on output messages, and corrected `Polling till temp...` to Polling `until`...

![image](https://cloud.githubusercontent.com/assets/10522484/14068639/8304590a-f43e-11e5-92db-9515a6e56c9a.png)
