### PR TITLE
Log Azure requests and responses.

### DIFF
--- a/packer/builder/azure/arm/azure_client.go
+++ b/packer/builder/azure/arm/azure_client.go
@@ -4,6 +4,8 @@
 package arm
 
 import (
+	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
@@ -11,6 +13,18 @@ import (
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/packer-azure/packer/builder/azure/common"
+	"github.com/Azure/packer-azure/version"
+	"math"
+	"os"
+	"strconv"
+)
+
+const (
+	EnvPackerLogAzureMaxLen = "PACKER_LOG_AZURE_MAXLEN"
+)
+
+var (
+	packerUserAgent = fmt.Sprintf(";packer/%s", version.Version)
 )
 
 type AzureClient struct {
@@ -21,6 +35,8 @@ type AzureClient struct {
 	compute.VirtualMachinesClient
 	common.VaultClient
 	armStorage.AccountsClient
+
+	InspectorMaxLength int
 }
 
 func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string,
@@ -28,23 +44,43 @@ func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string
 
 	var azureClient = &AzureClient{}
 
+	maxlen := getInspectorMaxLength()
+
 	azureClient.DeploymentsClient = resources.NewDeploymentsClient(subscriptionID)
 	azureClient.DeploymentsClient.Authorizer = servicePrincipalToken
+	azureClient.DeploymentsClient.RequestInspector = withInspection(maxlen)
+	azureClient.DeploymentsClient.ResponseInspector = byInspecting(maxlen)
+	azureClient.DeploymentsClient.UserAgent += packerUserAgent
 
 	azureClient.GroupsClient = resources.NewGroupsClient(subscriptionID)
 	azureClient.GroupsClient.Authorizer = servicePrincipalToken
+	azureClient.GroupsClient.RequestInspector = withInspection(maxlen)
+	azureClient.GroupsClient.ResponseInspector = byInspecting(maxlen)
+	azureClient.GroupsClient.UserAgent += packerUserAgent
 
 	azureClient.PublicIPAddressesClient = network.NewPublicIPAddressesClient(subscriptionID)
 	azureClient.PublicIPAddressesClient.Authorizer = servicePrincipalToken
+	azureClient.PublicIPAddressesClient.RequestInspector = withInspection(maxlen)
+	azureClient.PublicIPAddressesClient.ResponseInspector = byInspecting(maxlen)
+	azureClient.PublicIPAddressesClient.UserAgent += packerUserAgent
 
 	azureClient.VirtualMachinesClient = compute.NewVirtualMachinesClient(subscriptionID)
 	azureClient.VirtualMachinesClient.Authorizer = servicePrincipalToken
+	azureClient.VirtualMachinesClient.RequestInspector = withInspection(maxlen)
+	azureClient.VirtualMachinesClient.ResponseInspector = byInspecting(maxlen)
+	azureClient.PublicIPAddressesClient.UserAgent += packerUserAgent
 
 	azureClient.AccountsClient = armStorage.NewAccountsClient(subscriptionID)
 	azureClient.AccountsClient.Authorizer = servicePrincipalToken
+	azureClient.AccountsClient.RequestInspector = withInspection(maxlen)
+	azureClient.AccountsClient.ResponseInspector = byInspecting(maxlen)
+	azureClient.AccountsClient.UserAgent += packerUserAgent
 
 	azureClient.VaultClient = common.VaultClient{}
 	azureClient.VaultClient.Authorizer = servicePrincipalTokenVault
+	azureClient.VaultClient.RequestInspector = withInspection(maxlen)
+	azureClient.VaultClient.ResponseInspector = byInspecting(maxlen)
+	azureClient.VaultClient.UserAgent += packerUserAgent
 
 	accountKeys, err := azureClient.AccountsClient.ListKeys(resourceGroupName, storageAccountName)
 	if err != nil {
@@ -58,4 +94,22 @@ func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string
 
 	azureClient.BlobStorageClient = storageClient.GetBlobService()
 	return azureClient, nil
+}
+
+func getInspectorMaxLength() int64 {
+	value, ok := os.LookupEnv(EnvPackerLogAzureMaxLen)
+	if !ok {
+		return math.MaxInt64
+	}
+
+	i, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	if i < 0 {
+		return 0
+	}
+
+	return i
 }

--- a/packer/builder/azure/arm/builder.go
+++ b/packer/builder/azure/arm/builder.go
@@ -10,10 +10,10 @@ import (
 
 	packerAzureCommon "github.com/Azure/packer-azure/packer/builder/azure/common"
 
+	"github.com/Azure/go-autorest/autorest/azure"
+
 	"github.com/Azure/packer-azure/packer/builder/azure/common/constants"
 	"github.com/Azure/packer-azure/packer/builder/azure/common/lin"
-
-	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/common"

--- a/packer/builder/azure/arm/inspector.go
+++ b/packer/builder/azure/arm/inspector.go
@@ -1,0 +1,68 @@
+package arm
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/packer-azure/packer/builder/azure/common/logutil"
+	"io"
+)
+
+func chop(data []byte, maxlen int64) string {
+	s := string(data)
+	if int64(len(s)) > maxlen {
+		s = s[:maxlen] + "..."
+	}
+	return s
+}
+
+func handleBody(body io.ReadCloser, maxlen int64) (io.ReadCloser, string) {
+	if body == nil {
+		return nil, ""
+	}
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, ""
+	}
+
+	return ioutil.NopCloser(bytes.NewReader(b)), chop(b, maxlen)
+}
+
+func withInspection(maxlen int64) autorest.PrepareDecorator {
+	return func(p autorest.Preparer) autorest.Preparer {
+		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			body, bodyString := handleBody(r.Body, maxlen)
+			r.Body = body
+
+			log.Print("Azure request", logutil.Fields{
+				"method":  r.Method,
+				"request": r.URL.String(),
+				"body":    bodyString,
+			})
+			return p.Prepare(r)
+		})
+	}
+}
+
+func byInspecting(maxlen int64) autorest.RespondDecorator {
+	return func(r autorest.Responder) autorest.Responder {
+		return autorest.ResponderFunc(func(resp *http.Response) error {
+			body, bodyString := handleBody(resp.Body, maxlen)
+			resp.Body = body
+
+			log.Print("Azure response", logutil.Fields{
+				"status":          resp.Status,
+				"method":          resp.Request.Method,
+				"request":         resp.Request.URL.String(),
+				"x-ms-request-id": azure.ExtractRequestID(resp),
+				"body":            bodyString,
+			})
+			return r.Respond(resp)
+		})
+	}
+}

--- a/packer/builder/azure/arm/openssh_key_pair_test.go
+++ b/packer/builder/azure/arm/openssh_key_pair_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+func TestFart(t *testing.T) {
+
+}
+
 func TestAuthorizedKeyShouldParse(t *testing.T) {
 	testSubject, err := NewOpenSshKeyPairWithSize(512)
 	if err != nil {

--- a/packer/builder/azure/common/logutil/logfields.go
+++ b/packer/builder/azure/common/logutil/logfields.go
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package logutil
+
+import "fmt"
+
+type Fields map[string]interface{}
+
+func (f Fields) String() string {
+	var s string
+	for k, v := range f {
+		if sv, ok := v.(string); ok {
+			v = fmt.Sprintf("%q", sv)
+		}
+		s += fmt.Sprintf(" %s=%v", k, v)
+	}
+	return s
+}


### PR DESCRIPTION
The body is currently captured because it contains valuable information.
The downside is that the body is very big, and makes very noisy logs.  I'm
not sure if the happy medium is not to log the body because without it
diagnosing failures is very difficult.