### PR TITLE
Allow the user to set the image version.

### DIFF
--- a/config_examples/arm/CentOS_7.2.json
+++ b/config_examples/arm/CentOS_7.2.json
@@ -32,7 +32,8 @@
             "os_type": "Linux",
             "image_publisher": "OpenLogic",
             "image_offer": "CentOS",
-            "image_sku": "7.1",
+            "image_sku": "7.2",
+            "image_version": "7.2.20160303",
             "ssh_pty": "true",
 
             "location": "South Central US",

--- a/packer/builder/azure/arm/config.go
+++ b/packer/builder/azure/arm/config.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	DefaultUserName = "packer"
-	DefaultVMSize   = "Standard_A1"
+	DefaultImageVersion = "latest"
+	DefaultUserName     = "packer"
+	DefaultVMSize       = "Standard_A1"
 )
 
 type Config struct {
@@ -54,6 +55,7 @@ type Config struct {
 	ImagePublisher string `mapstructure:"image_publisher"`
 	ImageOffer     string `mapstructure:"image_offer"`
 	ImageSku       string `mapstructure:"image_sku"`
+	ImageVersion   string `mapstructure:"image_version"`
 	Location       string `mapstructure:"location"`
 	VMSize         string `mapstructure:"vm_size"`
 
@@ -105,6 +107,7 @@ func (c *Config) toTemplateParameters() *TemplateParameters {
 		ImageOffer:         &TemplateParameter{c.ImageOffer},
 		ImagePublisher:     &TemplateParameter{c.ImagePublisher},
 		ImageSku:           &TemplateParameter{c.ImageSku},
+		ImageVersion:       &TemplateParameter{c.ImageVersion},
 		OSDiskName:         &TemplateParameter{c.tmpOSDiskName},
 		StorageAccountName: &TemplateParameter{c.StorageAccount},
 		VMSize:             &TemplateParameter{c.VMSize},
@@ -306,6 +309,10 @@ func setUserNamePassword(c *Config) {
 func provideDefaultValues(c *Config) {
 	if c.VMSize == "" {
 		c.VMSize = DefaultVMSize
+	}
+
+	if c.ImageVersion == "" {
+		c.ImageVersion = DefaultImageVersion
 	}
 }
 

--- a/packer/builder/azure/arm/config_test.go
+++ b/packer/builder/azure/arm/config_test.go
@@ -92,6 +92,14 @@ func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
 	}
 }
 
+func TestConfigShouldDefaultImageVersionToLatest(t *testing.T) {
+	c, _, _ := newConfig(getArmBuilderConfiguration(), getPackerConfiguration())
+
+	if c.ImageVersion != "latest" {
+		t.Errorf("Expected 'ImageVersion' to default to 'latest', but got '%s'.", c.ImageVersion)
+	}
+}
+
 func TestUserShouldProvideRequiredValues(t *testing.T) {
 	builderValues := getArmBuilderConfiguration()
 

--- a/packer/builder/azure/arm/template.go
+++ b/packer/builder/azure/arm/template.go
@@ -19,13 +19,16 @@ const Linux = `{
       "type": "string"
     },
     "imagePublisher": {
-   	  "type": "string"
+      "type": "string"
     },
     "imageOffer": {
-   	  "type": "string"
+      "type": "string"
     },
     "imageSku": {
-   	  "type": "string"
+      "type": "string"
+    },
+    "imageVersion": {
+      "type": "string"
     },
     "osDiskName": {
       "type": "string"
@@ -151,7 +154,7 @@ const Linux = `{
             "publisher": "[parameters('imagePublisher')]",
             "offer": "[parameters('imageOffer')]",
             "sku": "[parameters('imageSku')]",
-            "version": "latest"
+            "version": "[parameters('imageVersion')]"
           },
           "osDisk": {
             "name": "osdisk",
@@ -204,6 +207,9 @@ const KeyVault = `{
       "type": "string"
     },
     "imageSku": {
+      "type": "string"
+    },
+    "imageVersion": {
       "type": "string"
     },
     "keyVaultName": {
@@ -301,6 +307,9 @@ const Windows = `{
       "type": "string"
     },
     "imageSku": {
+      "type": "string"
+    },
+    "imageVersion": {
       "type": "string"
     },
     "keyVaultName": {
@@ -451,7 +460,7 @@ const Windows = `{
             "publisher": "[parameters('imagePublisher')]",
             "offer": "[parameters('imageOffer')]",
             "sku": "[parameters('imageSku')]",
-            "version": "latest"
+	    "version": "[parameters('imageVersion')]"
           },
           "osDisk": {
             "name": "osdisk",

--- a/packer/builder/azure/arm/template_parameters.go
+++ b/packer/builder/azure/arm/template_parameters.go
@@ -27,6 +27,7 @@ type TemplateParameters struct {
 	ImageOffer          *TemplateParameter `json:"imageOffer,omitempty"`
 	ImagePublisher      *TemplateParameter `json:"imagePublisher,omitempty"`
 	ImageSku            *TemplateParameter `json:"imageSku,omitempty"`
+	ImageVersion        *TemplateParameter `json:"imageVersion,omitempty"`
 	KeyVaultName        *TemplateParameter `json:"keyVaultName,omitempty"`
 	KeyVaultSecretValue *TemplateParameter `json:"keyVaultSecretValue,omitempty"`
 	ObjectId            *TemplateParameter `json:"objectId,omitempty"`


### PR DESCRIPTION
The image version used to default to latest, which made reproducible
builds difficult if the image version changed frequently, or if regions
did not have the same latest version.