### PR TITLE
Update to latest azure-sdk-for-go

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,115 +1,114 @@
 {
 	"ImportPath": "github.com/Azure/packer-azure",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v60",
 	"Packages": [
 		"./..."
 	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/compute",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/network",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/resources/resources",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/storage",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/core/http",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/core/tls",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management/hostedservice",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management/location",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management/osimage",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management/storageservice",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management/virtualmachine",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management/virtualmachinedisk",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management/virtualmachineimage",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/management/vmutils",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/storage",
-			"Comment": "v1.2-336-gb0d8efa",
-			"Rev": "b0d8efa96c2e0f3708619ca9e6cd822eb8ada157"
+			"Comment": "v2.1.0-beta",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest",
-			"Comment": "v3.0.0-32-gbebca45",
-			"Rev": "bebca455f60b24bf6a2459e9e862ff42da86f5e0"
+			"Comment": "v7.0.3",
+			"Rev": "a48248c3a3a847d2359ce7c262b4e4686307256f"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/azure",
-			"Comment": "v3.0.0-32-gbebca45",
-			"Rev": "bebca455f60b24bf6a2459e9e862ff42da86f5e0"
+			"Comment": "v7.0.3",
+			"Rev": "a48248c3a3a847d2359ce7c262b4e4686307256f"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/date",
-			"Comment": "v3.0.0-32-gbebca45",
-			"Rev": "bebca455f60b24bf6a2459e9e862ff42da86f5e0"
+			"Comment": "v7.0.3",
+			"Rev": "a48248c3a3a847d2359ce7c262b4e4686307256f"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/to",
-			"Comment": "v3.0.0-32-gbebca45",
-			"Rev": "bebca455f60b24bf6a2459e9e862ff42da86f5e0"
+			"Comment": "v7.0.3",
+			"Rev": "a48248c3a3a847d2359ce7c262b4e4686307256f"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-ntlmssp",

--- a/packer/builder/azure/arm/step_capture_image_test.go
+++ b/packer/builder/azure/arm/step_capture_image_test.go
@@ -13,9 +13,8 @@ import (
 )
 
 func TestStepCaptureImageShouldFailIfCaptureFails(t *testing.T) {
-
 	var testSubject = &StepCaptureImage{
-		capture: func(string, string, *compute.VirtualMachineCaptureParameters) error {
+		capture: func(string, string, *compute.VirtualMachineCaptureParameters, <-chan struct{}) error {
 			return fmt.Errorf("!! Unit Test FAIL !!")
 		},
 		say:   func(message string) {},
@@ -36,7 +35,7 @@ func TestStepCaptureImageShouldFailIfCaptureFails(t *testing.T) {
 
 func TestStepCaptureImageShouldPassIfCapturePasses(t *testing.T) {
 	var testSubject = &StepCaptureImage{
-		capture: func(string, string, *compute.VirtualMachineCaptureParameters) error { return nil },
+		capture: func(string, string, *compute.VirtualMachineCaptureParameters, <-chan struct{}) error { return nil },
 		say:     func(message string) {},
 		error:   func(e error) {},
 	}
@@ -54,12 +53,15 @@ func TestStepCaptureImageShouldPassIfCapturePasses(t *testing.T) {
 }
 
 func TestStepCaptureImageShouldTakeStepArgumentsFromStateBag(t *testing.T) {
+	cancelCh := make(chan<- struct{})
+	defer close(cancelCh)
+
 	var actualResourceGroupName string
 	var actualComputeName string
 	var actualVirtualMachineCaptureParameters *compute.VirtualMachineCaptureParameters
 
 	var testSubject = &StepCaptureImage{
-		capture: func(resourceGroupName string, computeName string, parameters *compute.VirtualMachineCaptureParameters) error {
+		capture: func(resourceGroupName string, computeName string, parameters *compute.VirtualMachineCaptureParameters, cancelCh <-chan struct{}) error {
 			actualResourceGroupName = resourceGroupName
 			actualComputeName = computeName
 			actualVirtualMachineCaptureParameters = parameters

--- a/packer/builder/azure/arm/step_delete_os_disk.go
+++ b/packer/builder/azure/arm/step_delete_os_disk.go
@@ -33,7 +33,7 @@ func NewStepDeleteOSDisk(client *AzureClient, ui packer.Ui) *StepDeleteOSDisk {
 }
 
 func (s *StepDeleteOSDisk) deleteBlob(storageContainerName string, blobName string) error {
-	return s.client.BlobStorageClient.DeleteBlob(storageContainerName, blobName)
+	return s.client.BlobStorageClient.DeleteBlob(storageContainerName, blobName, nil)
 }
 
 func (s *StepDeleteOSDisk) Run(state multistep.StateBag) multistep.StepAction {

--- a/packer/builder/azure/arm/step_delete_resource_group.go
+++ b/packer/builder/azure/arm/step_delete_resource_group.go
@@ -5,9 +5,7 @@ package arm
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/packer-azure/packer/builder/azure/common"
 	"github.com/Azure/packer-azure/packer/builder/azure/common/constants"
 	"github.com/mitchellh/multistep"
@@ -16,7 +14,7 @@ import (
 
 type StepDeleteResourceGroup struct {
 	client *AzureClient
-	delete func(resourceGroupName string) error
+	delete func(resourceGroupName string, cancelCh <-chan struct{}) error
 	say    func(message string)
 	error  func(e error)
 }
@@ -32,40 +30,10 @@ func NewStepDeleteResourceGroup(client *AzureClient, ui packer.Ui) *StepDeleteRe
 	return step
 }
 
-func (s *StepDeleteResourceGroup) deleteResourceGroup(resourceGroupName string) error {
-	_, err := s.client.GroupsClient.Delete(resourceGroupName)
-	if err != nil {
-		return err
-	}
+func (s *StepDeleteResourceGroup) deleteResourceGroup(resourceGroupName string, cancelCh <-chan struct{}) error {
+	_, err := s.client.GroupsClient.Delete(resourceGroupName, cancelCh)
 
-	return s.waitForResourceGroupToBeDeleted(resourceGroupName)
-}
-
-// The API does not correctly poll for completion of the Delete command for the groups client, so here's a workaround.
-//
-// There are two polling variations that I am aware of.
-//  1. API returns a location header and HTTP status code of 202.  Client must poll the location until complete.
-//  2. API returns an azure async operation header.
-func (s *StepDeleteResourceGroup) waitForResourceGroupToBeDeleted(resourceGroupName string) error {
-	deadline := time.Now().Add(15 * time.Minute)
-	for {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("Exceeded poll duration while waiting for resource group %s to be deleted", resourceGroupName)
-		}
-
-		_, err := s.client.GroupsClient.Get(resourceGroupName)
-		if err != nil {
-			detailedError, ok := err.(autorest.DetailedError)
-			if ok && detailedError.StatusCode == 404 {
-				break
-			}
-
-		}
-
-		time.Sleep(15 * time.Second)
-	}
-
-	return nil
+	return err
 }
 
 func (s *StepDeleteResourceGroup) Run(state multistep.StateBag) multistep.StepAction {
@@ -76,7 +44,7 @@ func (s *StepDeleteResourceGroup) Run(state multistep.StateBag) multistep.StepAc
 
 	result := common.StartInterruptibleTask(
 		func() bool { return common.IsStateCancelled(state) },
-		func() error { return s.delete(resourceGroupName) })
+		func(cancelCh <-chan struct{}) error { return s.delete(resourceGroupName, cancelCh) })
 
 	return processInterruptibleResult(result, s.error, state)
 }

--- a/packer/builder/azure/arm/step_delete_resource_group_test.go
+++ b/packer/builder/azure/arm/step_delete_resource_group_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestStepDeleteResourceGroupShouldFailIfDeleteFails(t *testing.T) {
 	var testSubject = &StepDeleteResourceGroup{
-		delete: func(string) error { return fmt.Errorf("!! Unit Test FAIL !!") },
+		delete: func(string, <-chan struct{}) error { return fmt.Errorf("!! Unit Test FAIL !!") },
 		say:    func(message string) {},
 		error:  func(e error) {},
 	}
@@ -32,7 +32,7 @@ func TestStepDeleteResourceGroupShouldFailIfDeleteFails(t *testing.T) {
 
 func TestStepDeleteResourceGroupShouldPassIfDeletePasses(t *testing.T) {
 	var testSubject = &StepDeleteResourceGroup{
-		delete: func(string) error { return nil },
+		delete: func(string, <-chan struct{}) error { return nil },
 		say:    func(message string) {},
 		error:  func(e error) {},
 	}
@@ -53,7 +53,7 @@ func TestStepDeleteResourceGroupShouldTakeStepArgumentsFromStateBag(t *testing.T
 	var actualResourceGroupName string
 
 	var testSubject = &StepDeleteResourceGroup{
-		delete: func(resourceGroupName string) error {
+		delete: func(resourceGroupName string, cancelCh <-chan struct{}) error {
 			actualResourceGroupName = resourceGroupName
 			return nil
 		},

--- a/packer/builder/azure/arm/step_deploy_template_test.go
+++ b/packer/builder/azure/arm/step_deploy_template_test.go
@@ -14,9 +14,11 @@ import (
 func TestStepDeployTemplateShouldFailIfDeployFails(t *testing.T) {
 	var testSubject = &StepDeployTemplate{
 		template: Linux,
-		deploy:   func(string, string, *TemplateParameters) error { return fmt.Errorf("!! Unit Test FAIL !!") },
-		say:      func(message string) {},
-		error:    func(e error) {},
+		deploy: func(string, string, *TemplateParameters, <-chan struct{}) error {
+			return fmt.Errorf("!! Unit Test FAIL !!")
+		},
+		say:   func(message string) {},
+		error: func(e error) {},
 	}
 
 	stateBag := createTestStateBagStepDeployTemplate()
@@ -34,7 +36,7 @@ func TestStepDeployTemplateShouldFailIfDeployFails(t *testing.T) {
 func TestStepDeployTemplateShouldPassIfDeployPasses(t *testing.T) {
 	var testSubject = &StepDeployTemplate{
 		template: Linux,
-		deploy:   func(string, string, *TemplateParameters) error { return nil },
+		deploy:   func(string, string, *TemplateParameters, <-chan struct{}) error { return nil },
 		say:      func(message string) {},
 		error:    func(e error) {},
 	}
@@ -58,7 +60,7 @@ func TestStepDeployTemplateShouldTakeStepArgumentsFromStateBag(t *testing.T) {
 
 	var testSubject = &StepDeployTemplate{
 		template: Linux,
-		deploy: func(resourceGroupName string, deploymentName string, templateParameter *TemplateParameters) error {
+		deploy: func(resourceGroupName string, deploymentName string, templateParameter *TemplateParameters, cancelCh <-chan struct{}) error {
 			actualResourceGroupName = resourceGroupName
 			actualDeploymentName = deploymentName
 			actualTemplateParameters = templateParameter

--- a/packer/builder/azure/arm/step_power_off_compute_test.go
+++ b/packer/builder/azure/arm/step_power_off_compute_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestStepPowerOffComputeShouldFailIfPowerOffFails(t *testing.T) {
 	var testSubject = &StepPowerOffCompute{
-		powerOff: func(string, string) error { return fmt.Errorf("!! Unit Test FAIL !!") },
+		powerOff: func(string, string, <-chan struct{}) error { return fmt.Errorf("!! Unit Test FAIL !!") },
 		say:      func(message string) {},
 		error:    func(e error) {},
 	}
@@ -32,7 +32,7 @@ func TestStepPowerOffComputeShouldFailIfPowerOffFails(t *testing.T) {
 
 func TestStepPowerOffComputeShouldPassIfPowerOffPasses(t *testing.T) {
 	var testSubject = &StepPowerOffCompute{
-		powerOff: func(string, string) error { return nil },
+		powerOff: func(string, string, <-chan struct{}) error { return nil },
 		say:      func(message string) {},
 		error:    func(e error) {},
 	}
@@ -54,7 +54,7 @@ func TestStepPowerOffComputeShouldTakeStepArgumentsFromStateBag(t *testing.T) {
 	var actualComputeName string
 
 	var testSubject = &StepPowerOffCompute{
-		powerOff: func(resourceGroupName string, computeName string) error {
+		powerOff: func(resourceGroupName string, computeName string, cancelCh <-chan struct{}) error {
 			actualResourceGroupName = resourceGroupName
 			actualComputeName = computeName
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/availabilitysets.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/availabilitysets.go
@@ -47,7 +47,7 @@ func NewAvailabilitySetsClientWithBaseURI(baseURI string, subscriptionID string)
 // resourceGroupName is the name of the resource group. name is parameters
 // supplied to the Create Availability Set operation. parameters is
 // parameters supplied to the Create Availability Set operation.
-func (client AvailabilitySetsClient) CreateOrUpdate(resourceGroupName string, name string, parameters AvailabilitySet) (result AvailabilitySet, ae error) {
+func (client AvailabilitySetsClient) CreateOrUpdate(resourceGroupName string, name string, parameters AvailabilitySet) (result AvailabilitySet, err error) {
 	req, err := client.CreateOrUpdatePreparer(resourceGroupName, name, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "CreateOrUpdate", nil, "Failure preparing request")
@@ -61,7 +61,7 @@ func (client AvailabilitySetsClient) CreateOrUpdate(resourceGroupName string, na
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
@@ -92,7 +92,7 @@ func (client AvailabilitySetsClient) CreateOrUpdatePreparer(resourceGroupName st
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client AvailabilitySetsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -112,7 +112,7 @@ func (client AvailabilitySetsClient) CreateOrUpdateResponder(resp *http.Response
 //
 // resourceGroupName is the name of the resource group. availabilitySetName is
 // the name of the availability set.
-func (client AvailabilitySetsClient) Delete(resourceGroupName string, availabilitySetName string) (result autorest.Response, ae error) {
+func (client AvailabilitySetsClient) Delete(resourceGroupName string, availabilitySetName string) (result autorest.Response, err error) {
 	req, err := client.DeletePreparer(resourceGroupName, availabilitySetName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "Delete", nil, "Failure preparing request")
@@ -126,7 +126,7 @@ func (client AvailabilitySetsClient) Delete(resourceGroupName string, availabili
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
@@ -156,7 +156,7 @@ func (client AvailabilitySetsClient) DeletePreparer(resourceGroupName string, av
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client AvailabilitySetsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -175,7 +175,7 @@ func (client AvailabilitySetsClient) DeleteResponder(resp *http.Response) (resul
 //
 // resourceGroupName is the name of the resource group. availabilitySetName is
 // the name of the availability set.
-func (client AvailabilitySetsClient) Get(resourceGroupName string, availabilitySetName string) (result AvailabilitySet, ae error) {
+func (client AvailabilitySetsClient) Get(resourceGroupName string, availabilitySetName string) (result AvailabilitySet, err error) {
 	req, err := client.GetPreparer(resourceGroupName, availabilitySetName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "Get", nil, "Failure preparing request")
@@ -189,7 +189,7 @@ func (client AvailabilitySetsClient) Get(resourceGroupName string, availabilityS
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -219,7 +219,7 @@ func (client AvailabilitySetsClient) GetPreparer(resourceGroupName string, avail
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client AvailabilitySetsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -238,7 +238,7 @@ func (client AvailabilitySetsClient) GetResponder(resp *http.Response) (result A
 // List the operation to list the availability sets.
 //
 // resourceGroupName is the name of the resource group.
-func (client AvailabilitySetsClient) List(resourceGroupName string) (result AvailabilitySetListResult, ae error) {
+func (client AvailabilitySetsClient) List(resourceGroupName string) (result AvailabilitySetListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "List", nil, "Failure preparing request")
@@ -252,7 +252,7 @@ func (client AvailabilitySetsClient) List(resourceGroupName string) (result Avai
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -281,7 +281,7 @@ func (client AvailabilitySetsClient) ListPreparer(resourceGroupName string) (*ht
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client AvailabilitySetsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -298,7 +298,7 @@ func (client AvailabilitySetsClient) ListResponder(resp *http.Response) (result 
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client AvailabilitySetsClient) ListNextResults(lastResults AvailabilitySetListResult) (result AvailabilitySetListResult, ae error) {
+func (client AvailabilitySetsClient) ListNextResults(lastResults AvailabilitySetListResult) (result AvailabilitySetListResult, err error) {
 	req, err := lastResults.AvailabilitySetListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "List", nil, "Failure preparing next results request request")
@@ -315,7 +315,7 @@ func (client AvailabilitySetsClient) ListNextResults(lastResults AvailabilitySet
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -326,7 +326,7 @@ func (client AvailabilitySetsClient) ListNextResults(lastResults AvailabilitySet
 //
 // resourceGroupName is the name of the resource group. availabilitySetName is
 // the name of the availability set.
-func (client AvailabilitySetsClient) ListAvailableSizes(resourceGroupName string, availabilitySetName string) (result VirtualMachineSizeListResult, ae error) {
+func (client AvailabilitySetsClient) ListAvailableSizes(resourceGroupName string, availabilitySetName string) (result VirtualMachineSizeListResult, err error) {
 	req, err := client.ListAvailableSizesPreparer(resourceGroupName, availabilitySetName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "ListAvailableSizes", nil, "Failure preparing request")
@@ -340,7 +340,7 @@ func (client AvailabilitySetsClient) ListAvailableSizes(resourceGroupName string
 
 	result, err = client.ListAvailableSizesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "ListAvailableSizes", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "ListAvailableSizes", resp, "Failure responding to request")
 	}
 
 	return
@@ -370,7 +370,7 @@ func (client AvailabilitySetsClient) ListAvailableSizesPreparer(resourceGroupNam
 // ListAvailableSizesSender sends the ListAvailableSizes request. The method will close the
 // http.Response Body if it receives an error.
 func (client AvailabilitySetsClient) ListAvailableSizesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAvailableSizesResponder handles the response to the ListAvailableSizes request. The method always
@@ -387,7 +387,7 @@ func (client AvailabilitySetsClient) ListAvailableSizesResponder(resp *http.Resp
 }
 
 // ListAvailableSizesNextResults retrieves the next set of results, if any.
-func (client AvailabilitySetsClient) ListAvailableSizesNextResults(lastResults VirtualMachineSizeListResult) (result VirtualMachineSizeListResult, ae error) {
+func (client AvailabilitySetsClient) ListAvailableSizesNextResults(lastResults VirtualMachineSizeListResult) (result VirtualMachineSizeListResult, err error) {
 	req, err := lastResults.VirtualMachineSizeListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "ListAvailableSizes", nil, "Failure preparing next results request request")
@@ -404,7 +404,7 @@ func (client AvailabilitySetsClient) ListAvailableSizesNextResults(lastResults V
 
 	result, err = client.ListAvailableSizesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "ListAvailableSizes", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "ListAvailableSizes", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/client.go
@@ -1,7 +1,7 @@
 // Package compute implements the Azure ARM Compute service API version
 // 2015-06-15.
 //
-// The Compute Management Client..
+// The Compute Management Client.
 package compute
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/models.go
@@ -394,8 +394,8 @@ func (client AvailabilitySetListResult) AvailabilitySetListResultPreparer() (*ht
 
 // AvailabilitySetProperties is the instance view of a resource.
 type AvailabilitySetProperties struct {
-	PlatformUpdateDomainCount *int                  `json:"platformUpdateDomainCount,omitempty"`
-	PlatformFaultDomainCount  *int                  `json:"platformFaultDomainCount,omitempty"`
+	PlatformUpdateDomainCount *int32                `json:"platformUpdateDomainCount,omitempty"`
+	PlatformFaultDomainCount  *int32                `json:"platformFaultDomainCount,omitempty"`
 	VirtualMachines           *[]SubResource        `json:"virtualMachines,omitempty"`
 	Statuses                  *[]InstanceViewStatus `json:"statuses,omitempty"`
 }
@@ -415,18 +415,18 @@ type BootDiagnosticsInstanceView struct {
 
 // DataDisk is describes a data disk.
 type DataDisk struct {
-	Lun          *int                  `json:"lun,omitempty"`
+	Lun          *int32                `json:"lun,omitempty"`
 	Name         *string               `json:"name,omitempty"`
 	Vhd          *VirtualHardDisk      `json:"vhd,omitempty"`
 	Image        *VirtualHardDisk      `json:"image,omitempty"`
 	Caching      CachingTypes          `json:"caching,omitempty"`
 	CreateOption DiskCreateOptionTypes `json:"createOption,omitempty"`
-	DiskSizeGB   *int                  `json:"diskSizeGB,omitempty"`
+	DiskSizeGB   *int32                `json:"diskSizeGB,omitempty"`
 }
 
 // DataDiskImage is contains the data disk images information.
 type DataDiskImage struct {
-	Lun *int `json:"lun,omitempty"`
+	Lun *int32 `json:"lun,omitempty"`
 }
 
 // DeleteOperationResult is the compute long running operation response.
@@ -520,6 +520,12 @@ func (client ListUsagesResult) ListUsagesResultPreparer() (*http.Request, error)
 		autorest.WithBaseURL(to.String(client.NextLink)))
 }
 
+// ListVirtualMachineImageResource is
+type ListVirtualMachineImageResource struct {
+	autorest.Response `json:"-"`
+	Value             *[]VirtualMachineImageResource `json:"value,omitempty"`
+}
+
 // LongRunningOperationProperties is compute-specific operation properties,
 // including output
 type LongRunningOperationProperties struct {
@@ -563,7 +569,7 @@ type OSDisk struct {
 	Image              *VirtualHardDisk        `json:"image,omitempty"`
 	Caching            CachingTypes            `json:"caching,omitempty"`
 	CreateOption       DiskCreateOptionTypes   `json:"createOption,omitempty"`
-	DiskSizeGB         *int                    `json:"diskSizeGB,omitempty"`
+	DiskSizeGB         *int32                  `json:"diskSizeGB,omitempty"`
 }
 
 // OSDiskImage is contains the os disk image information.
@@ -611,7 +617,7 @@ type Resource struct {
 type Sku struct {
 	Name     *string `json:"name,omitempty"`
 	Tier     *string `json:"tier,omitempty"`
-	Capacity *int32  `json:"capacity,omitempty"`
+	Capacity *int64  `json:"capacity,omitempty"`
 }
 
 // SSHConfiguration is sSH configuration for Linux based VMs running on Azure
@@ -646,8 +652,8 @@ type UpgradePolicy struct {
 // Usage is describes Compute Resource Usage.
 type Usage struct {
 	Unit         UsageUnit  `json:"unit,omitempty"`
-	CurrentValue *int       `json:"currentValue,omitempty"`
-	Limit        *int32     `json:"limit,omitempty"`
+	CurrentValue *int32     `json:"currentValue,omitempty"`
+	Limit        *int64     `json:"limit,omitempty"`
 	Name         *UsageName `json:"name,omitempty"`
 }
 
@@ -805,16 +811,10 @@ type VirtualMachineImageResource struct {
 	Tags     *map[string]*string `json:"tags,omitempty"`
 }
 
-// VirtualMachineImageResourceList is
-type VirtualMachineImageResourceList struct {
-	autorest.Response `json:"-"`
-	Value             *VirtualMachineImageResource `json:"value,omitempty"`
-}
-
 // VirtualMachineInstanceView is the instance view of a virtual machine.
 type VirtualMachineInstanceView struct {
-	PlatformUpdateDomain *int                                   `json:"platformUpdateDomain,omitempty"`
-	PlatformFaultDomain  *int                                   `json:"platformFaultDomain,omitempty"`
+	PlatformUpdateDomain *int32                                 `json:"platformUpdateDomain,omitempty"`
+	PlatformFaultDomain  *int32                                 `json:"platformFaultDomain,omitempty"`
 	RdpThumbPrint        *string                                `json:"rdpThumbPrint,omitempty"`
 	VMAgent              *VirtualMachineAgentInstanceView       `json:"vmAgent,omitempty"`
 	Disks                *[]DiskInstanceView                    `json:"disks,omitempty"`
@@ -1044,9 +1044,9 @@ type VirtualMachineScaleSetSku struct {
 
 // VirtualMachineScaleSetSkuCapacity is describes scaling information of a sku.
 type VirtualMachineScaleSetSkuCapacity struct {
-	Minimum         *int32                             `json:"minimum,omitempty"`
-	Maximum         *int32                             `json:"maximum,omitempty"`
-	DefaultCapacity *int32                             `json:"defaultCapacity,omitempty"`
+	Minimum         *int64                             `json:"minimum,omitempty"`
+	Maximum         *int64                             `json:"maximum,omitempty"`
+	DefaultCapacity *int64                             `json:"defaultCapacity,omitempty"`
 	ScaleType       VirtualMachineScaleSetSkuScaleType `json:"scaleType,omitempty"`
 }
 
@@ -1096,8 +1096,8 @@ type VirtualMachineScaleSetVMInstanceRequiredIDs struct {
 // machine scale set VM.
 type VirtualMachineScaleSetVMInstanceView struct {
 	autorest.Response    `json:"-"`
-	PlatformUpdateDomain *int                                   `json:"platformUpdateDomain,omitempty"`
-	PlatformFaultDomain  *int                                   `json:"platformFaultDomain,omitempty"`
+	PlatformUpdateDomain *int32                                 `json:"platformUpdateDomain,omitempty"`
+	PlatformFaultDomain  *int32                                 `json:"platformFaultDomain,omitempty"`
 	RdpThumbPrint        *string                                `json:"rdpThumbPrint,omitempty"`
 	VMAgent              *VirtualMachineAgentInstanceView       `json:"vmAgent,omitempty"`
 	Disks                *[]DiskInstanceView                    `json:"disks,omitempty"`
@@ -1152,11 +1152,11 @@ type VirtualMachineScaleSetVMProperties struct {
 // VirtualMachineSize is describes the properties of a VM size.
 type VirtualMachineSize struct {
 	Name                 *string `json:"name,omitempty"`
-	NumberOfCores        *int    `json:"numberOfCores,omitempty"`
-	OsDiskSizeInMB       *int    `json:"osDiskSizeInMB,omitempty"`
-	ResourceDiskSizeInMB *int    `json:"resourceDiskSizeInMB,omitempty"`
-	MemoryInMB           *int    `json:"memoryInMB,omitempty"`
-	MaxDataDiskCount     *int    `json:"maxDataDiskCount,omitempty"`
+	NumberOfCores        *int32  `json:"numberOfCores,omitempty"`
+	OsDiskSizeInMB       *int32  `json:"osDiskSizeInMB,omitempty"`
+	ResourceDiskSizeInMB *int32  `json:"resourceDiskSizeInMB,omitempty"`
+	MemoryInMB           *int32  `json:"memoryInMB,omitempty"`
+	MaxDataDiskCount     *int32  `json:"maxDataDiskCount,omitempty"`
 }
 
 // VirtualMachineSizeListResult is the List Virtual Machine operation response.
@@ -1182,7 +1182,7 @@ func (client VirtualMachineSizeListResult) VirtualMachineSizeListResultPreparer(
 // machine scale set instance view status summary.
 type VirtualMachineStatusCodeCount struct {
 	Code  *string `json:"code,omitempty"`
-	Count *int    `json:"count,omitempty"`
+	Count *int32  `json:"count,omitempty"`
 }
 
 // WindowsConfiguration is describes Windows Configuration of the OS Profile.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/usageoperations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/usageoperations.go
@@ -45,7 +45,7 @@ func NewUsageOperationsClientWithBaseURI(baseURI string, subscriptionID string) 
 // List lists compute usages for a subscription.
 //
 // location is the location upon which resource usage is queried.
-func (client UsageOperationsClient) List(location string) (result ListUsagesResult, ae error) {
+func (client UsageOperationsClient) List(location string) (result ListUsagesResult, err error) {
 	req, err := client.ListPreparer(location)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/UsageOperationsClient", "List", nil, "Failure preparing request")
@@ -59,7 +59,7 @@ func (client UsageOperationsClient) List(location string) (result ListUsagesResu
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/UsageOperationsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/UsageOperationsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -88,7 +88,7 @@ func (client UsageOperationsClient) ListPreparer(location string) (*http.Request
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client UsageOperationsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -105,7 +105,7 @@ func (client UsageOperationsClient) ListResponder(resp *http.Response) (result L
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client UsageOperationsClient) ListNextResults(lastResults ListUsagesResult) (result ListUsagesResult, ae error) {
+func (client UsageOperationsClient) ListNextResults(lastResults ListUsagesResult) (result ListUsagesResult, err error) {
 	req, err := lastResults.ListUsagesResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/UsageOperationsClient", "List", nil, "Failure preparing next results request request")
@@ -122,7 +122,7 @@ func (client UsageOperationsClient) ListNextResults(lastResults ListUsagesResult
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/UsageOperationsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/UsageOperationsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "5"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineextensionimages.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineextensionimages.go
@@ -44,7 +44,7 @@ func NewVirtualMachineExtensionImagesClientWithBaseURI(baseURI string, subscript
 
 // Get gets a virtual machine extension image.
 //
-func (client VirtualMachineExtensionImagesClient) Get(location string, publisherName string, typeParameter string, version string) (result VirtualMachineExtensionImage, ae error) {
+func (client VirtualMachineExtensionImagesClient) Get(location string, publisherName string, typeParameter string, version string) (result VirtualMachineExtensionImage, err error) {
 	req, err := client.GetPreparer(location, publisherName, typeParameter, version)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "Get", nil, "Failure preparing request")
@@ -58,7 +58,7 @@ func (client VirtualMachineExtensionImagesClient) Get(location string, publisher
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -90,7 +90,7 @@ func (client VirtualMachineExtensionImagesClient) GetPreparer(location string, p
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineExtensionImagesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -108,7 +108,7 @@ func (client VirtualMachineExtensionImagesClient) GetResponder(resp *http.Respon
 
 // ListTypes gets a list of virtual machine extension image types.
 //
-func (client VirtualMachineExtensionImagesClient) ListTypes(location string, publisherName string) (result VirtualMachineImageResourceList, ae error) {
+func (client VirtualMachineExtensionImagesClient) ListTypes(location string, publisherName string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListTypesPreparer(location, publisherName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListTypes", nil, "Failure preparing request")
@@ -122,7 +122,7 @@ func (client VirtualMachineExtensionImagesClient) ListTypes(location string, pub
 
 	result, err = client.ListTypesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListTypes", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListTypes", resp, "Failure responding to request")
 	}
 
 	return
@@ -152,12 +152,12 @@ func (client VirtualMachineExtensionImagesClient) ListTypesPreparer(location str
 // ListTypesSender sends the ListTypes request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineExtensionImagesClient) ListTypesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListTypesResponder handles the response to the ListTypes request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineExtensionImagesClient) ListTypesResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineExtensionImagesClient) ListTypesResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -171,7 +171,7 @@ func (client VirtualMachineExtensionImagesClient) ListTypesResponder(resp *http.
 // ListVersions gets a list of virtual machine extension image versions.
 //
 // filter is the filter to apply on the operation.
-func (client VirtualMachineExtensionImagesClient) ListVersions(location string, publisherName string, typeParameter string, filter string, top *int, orderBy string) (result VirtualMachineImageResourceList, ae error) {
+func (client VirtualMachineExtensionImagesClient) ListVersions(location string, publisherName string, typeParameter string, filter string, top *int32, orderBy string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListVersionsPreparer(location, publisherName, typeParameter, filter, top, orderBy)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListVersions", nil, "Failure preparing request")
@@ -185,14 +185,14 @@ func (client VirtualMachineExtensionImagesClient) ListVersions(location string, 
 
 	result, err = client.ListVersionsResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListVersions", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListVersions", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListVersionsPreparer prepares the ListVersions request.
-func (client VirtualMachineExtensionImagesClient) ListVersionsPreparer(location string, publisherName string, typeParameter string, filter string, top *int, orderBy string) (*http.Request, error) {
+func (client VirtualMachineExtensionImagesClient) ListVersionsPreparer(location string, publisherName string, typeParameter string, filter string, top *int32, orderBy string) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"location":       url.QueryEscape(location),
 		"publisherName":  url.QueryEscape(publisherName),
@@ -225,12 +225,12 @@ func (client VirtualMachineExtensionImagesClient) ListVersionsPreparer(location 
 // ListVersionsSender sends the ListVersions request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineExtensionImagesClient) ListVersionsSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListVersionsResponder handles the response to the ListVersions request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineExtensionImagesClient) ListVersionsResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineExtensionImagesClient) ListVersionsResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineextensions.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineextensions.go
@@ -42,35 +42,38 @@ func NewVirtualMachineExtensionsClientWithBaseURI(baseURI string, subscriptionID
 	return VirtualMachineExtensionsClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// CreateOrUpdate the operation to create or update the extension.
+// CreateOrUpdate the operation to create or update the extension. This method
+// may poll for completion. Polling can be canceled by passing the cancel
+// channel argument. The channel will be used to cancel polling and any
+// outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine where the extension should be create or updated.
 // vmExtensionName is the name of the virtual machine extension.
 // extensionParameters is parameters supplied to the Create Virtual Machine
 // Extension operation.
-func (client VirtualMachineExtensionsClient) CreateOrUpdate(resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension) (result VirtualMachineExtension, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, vmName, vmExtensionName, extensionParameters)
+func (client VirtualMachineExtensionsClient) CreateOrUpdate(resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, vmName, vmExtensionName, extensionParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualMachineExtensionsClient) CreateOrUpdatePreparer(resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*http.Request, error) {
+func (client VirtualMachineExtensionsClient) CreateOrUpdatePreparer(resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -82,7 +85,7 @@ func (client VirtualMachineExtensionsClient) CreateOrUpdatePreparer(resourceGrou
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -95,29 +98,33 @@ func (client VirtualMachineExtensionsClient) CreateOrUpdatePreparer(resourceGrou
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineExtensionsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineExtensionsClient) CreateOrUpdateResponder(resp *http.Response) (result VirtualMachineExtension, err error) {
+func (client VirtualMachineExtensionsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
-// Delete the operation to delete the extension.
+// Delete the operation to delete the extension. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine where the extension should be deleted. vmExtensionName
 // is the name of the virtual machine extension.
-func (client VirtualMachineExtensionsClient) Delete(resourceGroupName string, vmName string, vmExtensionName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, vmName, vmExtensionName)
+func (client VirtualMachineExtensionsClient) Delete(resourceGroupName string, vmName string, vmExtensionName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, vmName, vmExtensionName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -130,14 +137,14 @@ func (client VirtualMachineExtensionsClient) Delete(resourceGroupName string, vm
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualMachineExtensionsClient) DeletePreparer(resourceGroupName string, vmName string, vmExtensionName string) (*http.Request, error) {
+func (client VirtualMachineExtensionsClient) DeletePreparer(resourceGroupName string, vmName string, vmExtensionName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -149,7 +156,7 @@ func (client VirtualMachineExtensionsClient) DeletePreparer(resourceGroupName st
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -161,7 +168,9 @@ func (client VirtualMachineExtensionsClient) DeletePreparer(resourceGroupName st
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineExtensionsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -182,7 +191,7 @@ func (client VirtualMachineExtensionsClient) DeleteResponder(resp *http.Response
 // the virtual machine containing the extension. vmExtensionName is the name
 // of the virtual machine extension. expand is the expand expression to apply
 // on the operation.
-func (client VirtualMachineExtensionsClient) Get(resourceGroupName string, vmName string, vmExtensionName string, expand string) (result VirtualMachineExtension, ae error) {
+func (client VirtualMachineExtensionsClient) Get(resourceGroupName string, vmName string, vmExtensionName string, expand string) (result VirtualMachineExtension, err error) {
 	req, err := client.GetPreparer(resourceGroupName, vmName, vmExtensionName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Get", nil, "Failure preparing request")
@@ -196,7 +205,7 @@ func (client VirtualMachineExtensionsClient) Get(resourceGroupName string, vmNam
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -230,7 +239,7 @@ func (client VirtualMachineExtensionsClient) GetPreparer(resourceGroupName strin
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineExtensionsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineimages.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineimages.go
@@ -44,7 +44,7 @@ func NewVirtualMachineImagesClientWithBaseURI(baseURI string, subscriptionID str
 
 // Get gets a virtual machine image.
 //
-func (client VirtualMachineImagesClient) Get(location string, publisherName string, offer string, skus string, version string) (result VirtualMachineImage, ae error) {
+func (client VirtualMachineImagesClient) Get(location string, publisherName string, offer string, skus string, version string) (result VirtualMachineImage, err error) {
 	req, err := client.GetPreparer(location, publisherName, offer, skus, version)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "Get", nil, "Failure preparing request")
@@ -58,7 +58,7 @@ func (client VirtualMachineImagesClient) Get(location string, publisherName stri
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -91,7 +91,7 @@ func (client VirtualMachineImagesClient) GetPreparer(location string, publisherN
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineImagesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -110,7 +110,7 @@ func (client VirtualMachineImagesClient) GetResponder(resp *http.Response) (resu
 // List gets a list of virtual machine images.
 //
 // filter is the filter to apply on the operation.
-func (client VirtualMachineImagesClient) List(location string, publisherName string, offer string, skus string, filter string, top *int, orderby string) (result VirtualMachineImageResourceList, ae error) {
+func (client VirtualMachineImagesClient) List(location string, publisherName string, offer string, skus string, filter string, top *int32, orderby string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListPreparer(location, publisherName, offer, skus, filter, top, orderby)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "List", nil, "Failure preparing request")
@@ -124,14 +124,14 @@ func (client VirtualMachineImagesClient) List(location string, publisherName str
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListPreparer prepares the List request.
-func (client VirtualMachineImagesClient) ListPreparer(location string, publisherName string, offer string, skus string, filter string, top *int, orderby string) (*http.Request, error) {
+func (client VirtualMachineImagesClient) ListPreparer(location string, publisherName string, offer string, skus string, filter string, top *int32, orderby string) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"location":       url.QueryEscape(location),
 		"offer":          url.QueryEscape(offer),
@@ -165,12 +165,12 @@ func (client VirtualMachineImagesClient) ListPreparer(location string, publisher
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineImagesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineImagesClient) ListResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -183,7 +183,7 @@ func (client VirtualMachineImagesClient) ListResponder(resp *http.Response) (res
 
 // ListOffers gets a list of virtual machine image offers.
 //
-func (client VirtualMachineImagesClient) ListOffers(location string, publisherName string) (result VirtualMachineImageResourceList, ae error) {
+func (client VirtualMachineImagesClient) ListOffers(location string, publisherName string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListOffersPreparer(location, publisherName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListOffers", nil, "Failure preparing request")
@@ -197,7 +197,7 @@ func (client VirtualMachineImagesClient) ListOffers(location string, publisherNa
 
 	result, err = client.ListOffersResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListOffers", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListOffers", resp, "Failure responding to request")
 	}
 
 	return
@@ -227,12 +227,12 @@ func (client VirtualMachineImagesClient) ListOffersPreparer(location string, pub
 // ListOffersSender sends the ListOffers request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineImagesClient) ListOffersSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListOffersResponder handles the response to the ListOffers request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineImagesClient) ListOffersResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListOffersResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -245,7 +245,7 @@ func (client VirtualMachineImagesClient) ListOffersResponder(resp *http.Response
 
 // ListPublishers gets a list of virtual machine image publishers.
 //
-func (client VirtualMachineImagesClient) ListPublishers(location string) (result VirtualMachineImageResourceList, ae error) {
+func (client VirtualMachineImagesClient) ListPublishers(location string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListPublishersPreparer(location)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListPublishers", nil, "Failure preparing request")
@@ -259,7 +259,7 @@ func (client VirtualMachineImagesClient) ListPublishers(location string) (result
 
 	result, err = client.ListPublishersResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListPublishers", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListPublishers", resp, "Failure responding to request")
 	}
 
 	return
@@ -288,12 +288,12 @@ func (client VirtualMachineImagesClient) ListPublishersPreparer(location string)
 // ListPublishersSender sends the ListPublishers request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineImagesClient) ListPublishersSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListPublishersResponder handles the response to the ListPublishers request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineImagesClient) ListPublishersResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListPublishersResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -306,7 +306,7 @@ func (client VirtualMachineImagesClient) ListPublishersResponder(resp *http.Resp
 
 // ListSkus gets a list of virtual machine image skus.
 //
-func (client VirtualMachineImagesClient) ListSkus(location string, publisherName string, offer string) (result VirtualMachineImageResourceList, ae error) {
+func (client VirtualMachineImagesClient) ListSkus(location string, publisherName string, offer string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListSkusPreparer(location, publisherName, offer)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListSkus", nil, "Failure preparing request")
@@ -320,7 +320,7 @@ func (client VirtualMachineImagesClient) ListSkus(location string, publisherName
 
 	result, err = client.ListSkusResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListSkus", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListSkus", resp, "Failure responding to request")
 	}
 
 	return
@@ -351,12 +351,12 @@ func (client VirtualMachineImagesClient) ListSkusPreparer(location string, publi
 // ListSkusSender sends the ListSkus request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineImagesClient) ListSkusSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListSkusResponder handles the response to the ListSkus request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineImagesClient) ListSkusResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListSkusResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachines.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachines.go
@@ -43,33 +43,36 @@ func NewVirtualMachinesClientWithBaseURI(baseURI string, subscriptionID string) 
 }
 
 // Capture captures the VM by copying VirtualHardDisks of the VM and outputs a
-// template that can be used to create similar VMs.
+// template that can be used to create similar VMs. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine. parameters is parameters supplied to the Capture
 // Virtual Machine operation.
-func (client VirtualMachinesClient) Capture(resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters) (result VirtualMachineCaptureResult, ae error) {
-	req, err := client.CapturePreparer(resourceGroupName, vmName, parameters)
+func (client VirtualMachinesClient) Capture(resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CapturePreparer(resourceGroupName, vmName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Capture", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CaptureSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Capture", resp, "Failure sending request")
 	}
 
 	result, err = client.CaptureResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Capture", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Capture", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CapturePreparer prepares the Capture request.
-func (client VirtualMachinesClient) CapturePreparer(resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters) (*http.Request, error) {
+func (client VirtualMachinesClient) CapturePreparer(resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -80,7 +83,7 @@ func (client VirtualMachinesClient) CapturePreparer(resourceGroupName string, vm
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -93,49 +96,53 @@ func (client VirtualMachinesClient) CapturePreparer(resourceGroupName string, vm
 // CaptureSender sends the Capture request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) CaptureSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CaptureResponder handles the response to the Capture request. The method always
 // closes the http.Response Body.
-func (client VirtualMachinesClient) CaptureResponder(resp *http.Response) (result VirtualMachineCaptureResult, err error) {
+func (client VirtualMachinesClient) CaptureResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
-// CreateOrUpdate the operation to create or update a virtual machine.
+// CreateOrUpdate the operation to create or update a virtual machine. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine. parameters is parameters supplied to the Create
 // Virtual Machine operation.
-func (client VirtualMachinesClient) CreateOrUpdate(resourceGroupName string, vmName string, parameters VirtualMachine) (result VirtualMachine, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, vmName, parameters)
+func (client VirtualMachinesClient) CreateOrUpdate(resourceGroupName string, vmName string, parameters VirtualMachine, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, vmName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualMachinesClient) CreateOrUpdatePreparer(resourceGroupName string, vmName string, parameters VirtualMachine) (*http.Request, error) {
+func (client VirtualMachinesClient) CreateOrUpdatePreparer(resourceGroupName string, vmName string, parameters VirtualMachine, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -146,7 +153,7 @@ func (client VirtualMachinesClient) CreateOrUpdatePreparer(resourceGroupName str
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -159,30 +166,33 @@ func (client VirtualMachinesClient) CreateOrUpdatePreparer(resourceGroupName str
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client VirtualMachinesClient) CreateOrUpdateResponder(resp *http.Response) (result VirtualMachine, err error) {
+func (client VirtualMachinesClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Deallocate shuts down the Virtual Machine and releases the compute
 // resources. You are not billed for the compute resources that this Virtual
-// Machine uses.
+// Machine uses. This method may poll for completion. Polling can be canceled
+// by passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Deallocate(resourceGroupName string, vmName string) (result autorest.Response, ae error) {
-	req, err := client.DeallocatePreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) Deallocate(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeallocatePreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Deallocate", nil, "Failure preparing request")
 	}
@@ -195,14 +205,14 @@ func (client VirtualMachinesClient) Deallocate(resourceGroupName string, vmName 
 
 	result, err = client.DeallocateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Deallocate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Deallocate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeallocatePreparer prepares the Deallocate request.
-func (client VirtualMachinesClient) DeallocatePreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) DeallocatePreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -213,7 +223,7 @@ func (client VirtualMachinesClient) DeallocatePreparer(resourceGroupName string,
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -225,7 +235,9 @@ func (client VirtualMachinesClient) DeallocatePreparer(resourceGroupName string,
 // DeallocateSender sends the Deallocate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) DeallocateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeallocateResponder handles the response to the Deallocate request. The method always
@@ -240,12 +252,15 @@ func (client VirtualMachinesClient) DeallocateResponder(resp *http.Response) (re
 	return
 }
 
-// Delete the operation to delete a virtual machine.
+// Delete the operation to delete a virtual machine. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Delete(resourceGroupName string, vmName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) Delete(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -258,14 +273,14 @@ func (client VirtualMachinesClient) Delete(resourceGroupName string, vmName stri
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualMachinesClient) DeletePreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) DeletePreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -276,7 +291,7 @@ func (client VirtualMachinesClient) DeletePreparer(resourceGroupName string, vmN
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -288,7 +303,9 @@ func (client VirtualMachinesClient) DeletePreparer(resourceGroupName string, vmN
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -307,7 +324,7 @@ func (client VirtualMachinesClient) DeleteResponder(resp *http.Response) (result
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Generalize(resourceGroupName string, vmName string) (result autorest.Response, ae error) {
+func (client VirtualMachinesClient) Generalize(resourceGroupName string, vmName string) (result autorest.Response, err error) {
 	req, err := client.GeneralizePreparer(resourceGroupName, vmName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Generalize", nil, "Failure preparing request")
@@ -321,7 +338,7 @@ func (client VirtualMachinesClient) Generalize(resourceGroupName string, vmName 
 
 	result, err = client.GeneralizeResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Generalize", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Generalize", resp, "Failure responding to request")
 	}
 
 	return
@@ -351,7 +368,7 @@ func (client VirtualMachinesClient) GeneralizePreparer(resourceGroupName string,
 // GeneralizeSender sends the Generalize request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) GeneralizeSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GeneralizeResponder handles the response to the Generalize request. The method always
@@ -371,7 +388,7 @@ func (client VirtualMachinesClient) GeneralizeResponder(resp *http.Response) (re
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine. expand is the expand expression to apply on the
 // operation.
-func (client VirtualMachinesClient) Get(resourceGroupName string, vmName string, expand string) (result VirtualMachine, ae error) {
+func (client VirtualMachinesClient) Get(resourceGroupName string, vmName string, expand string) (result VirtualMachine, err error) {
 	req, err := client.GetPreparer(resourceGroupName, vmName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Get", nil, "Failure preparing request")
@@ -385,7 +402,7 @@ func (client VirtualMachinesClient) Get(resourceGroupName string, vmName string,
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -418,7 +435,7 @@ func (client VirtualMachinesClient) GetPreparer(resourceGroupName string, vmName
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -437,7 +454,7 @@ func (client VirtualMachinesClient) GetResponder(resp *http.Response) (result Vi
 // List the operation to list virtual machines under a resource group.
 //
 // resourceGroupName is the name of the resource group.
-func (client VirtualMachinesClient) List(resourceGroupName string) (result VirtualMachineListResult, ae error) {
+func (client VirtualMachinesClient) List(resourceGroupName string) (result VirtualMachineListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "List", nil, "Failure preparing request")
@@ -451,7 +468,7 @@ func (client VirtualMachinesClient) List(resourceGroupName string) (result Virtu
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -480,7 +497,7 @@ func (client VirtualMachinesClient) ListPreparer(resourceGroupName string) (*htt
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -497,7 +514,7 @@ func (client VirtualMachinesClient) ListResponder(resp *http.Response) (result V
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client VirtualMachinesClient) ListNextResults(lastResults VirtualMachineListResult) (result VirtualMachineListResult, ae error) {
+func (client VirtualMachinesClient) ListNextResults(lastResults VirtualMachineListResult) (result VirtualMachineListResult, err error) {
 	req, err := lastResults.VirtualMachineListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "List", nil, "Failure preparing next results request request")
@@ -514,7 +531,7 @@ func (client VirtualMachinesClient) ListNextResults(lastResults VirtualMachineLi
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -523,7 +540,7 @@ func (client VirtualMachinesClient) ListNextResults(lastResults VirtualMachineLi
 // ListAll gets the list of Virtual Machines in the subscription. Use nextLink
 // property in the response to get the next page of Virtual Machines. Do this
 // till nextLink is not null to fetch all the Virtual Machines.
-func (client VirtualMachinesClient) ListAll() (result VirtualMachineListResult, ae error) {
+func (client VirtualMachinesClient) ListAll() (result VirtualMachineListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAll", nil, "Failure preparing request")
@@ -537,7 +554,7 @@ func (client VirtualMachinesClient) ListAll() (result VirtualMachineListResult, 
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -565,7 +582,7 @@ func (client VirtualMachinesClient) ListAllPreparer() (*http.Request, error) {
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -582,7 +599,7 @@ func (client VirtualMachinesClient) ListAllResponder(resp *http.Response) (resul
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client VirtualMachinesClient) ListAllNextResults(lastResults VirtualMachineListResult) (result VirtualMachineListResult, ae error) {
+func (client VirtualMachinesClient) ListAllNextResults(lastResults VirtualMachineListResult) (result VirtualMachineListResult, err error) {
 	req, err := lastResults.VirtualMachineListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAll", nil, "Failure preparing next results request request")
@@ -599,7 +616,7 @@ func (client VirtualMachinesClient) ListAllNextResults(lastResults VirtualMachin
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -610,7 +627,7 @@ func (client VirtualMachinesClient) ListAllNextResults(lastResults VirtualMachin
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) ListAvailableSizes(resourceGroupName string, vmName string) (result VirtualMachineSizeListResult, ae error) {
+func (client VirtualMachinesClient) ListAvailableSizes(resourceGroupName string, vmName string) (result VirtualMachineSizeListResult, err error) {
 	req, err := client.ListAvailableSizesPreparer(resourceGroupName, vmName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAvailableSizes", nil, "Failure preparing request")
@@ -624,7 +641,7 @@ func (client VirtualMachinesClient) ListAvailableSizes(resourceGroupName string,
 
 	result, err = client.ListAvailableSizesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAvailableSizes", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAvailableSizes", resp, "Failure responding to request")
 	}
 
 	return
@@ -654,7 +671,7 @@ func (client VirtualMachinesClient) ListAvailableSizesPreparer(resourceGroupName
 // ListAvailableSizesSender sends the ListAvailableSizes request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) ListAvailableSizesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAvailableSizesResponder handles the response to the ListAvailableSizes request. The method always
@@ -671,7 +688,7 @@ func (client VirtualMachinesClient) ListAvailableSizesResponder(resp *http.Respo
 }
 
 // ListAvailableSizesNextResults retrieves the next set of results, if any.
-func (client VirtualMachinesClient) ListAvailableSizesNextResults(lastResults VirtualMachineSizeListResult) (result VirtualMachineSizeListResult, ae error) {
+func (client VirtualMachinesClient) ListAvailableSizesNextResults(lastResults VirtualMachineSizeListResult) (result VirtualMachineSizeListResult, err error) {
 	req, err := lastResults.VirtualMachineSizeListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAvailableSizes", nil, "Failure preparing next results request request")
@@ -688,18 +705,21 @@ func (client VirtualMachinesClient) ListAvailableSizesNextResults(lastResults Vi
 
 	result, err = client.ListAvailableSizesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAvailableSizes", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAvailableSizes", resp, "Failure responding to next results request request")
 	}
 
 	return
 }
 
-// PowerOff the operation to power off (stop) a virtual machine.
+// PowerOff the operation to power off (stop) a virtual machine. This method
+// may poll for completion. Polling can be canceled by passing the cancel
+// channel argument. The channel will be used to cancel polling and any
+// outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) PowerOff(resourceGroupName string, vmName string) (result autorest.Response, ae error) {
-	req, err := client.PowerOffPreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) PowerOff(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.PowerOffPreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "PowerOff", nil, "Failure preparing request")
 	}
@@ -712,14 +732,14 @@ func (client VirtualMachinesClient) PowerOff(resourceGroupName string, vmName st
 
 	result, err = client.PowerOffResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "PowerOff", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "PowerOff", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // PowerOffPreparer prepares the PowerOff request.
-func (client VirtualMachinesClient) PowerOffPreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) PowerOffPreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -730,7 +750,7 @@ func (client VirtualMachinesClient) PowerOffPreparer(resourceGroupName string, v
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -742,7 +762,9 @@ func (client VirtualMachinesClient) PowerOffPreparer(resourceGroupName string, v
 // PowerOffSender sends the PowerOff request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) PowerOffSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // PowerOffResponder handles the response to the PowerOff request. The method always
@@ -757,12 +779,15 @@ func (client VirtualMachinesClient) PowerOffResponder(resp *http.Response) (resu
 	return
 }
 
-// Restart the operation to restart a virtual machine.
+// Restart the operation to restart a virtual machine. This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Restart(resourceGroupName string, vmName string) (result autorest.Response, ae error) {
-	req, err := client.RestartPreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) Restart(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.RestartPreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Restart", nil, "Failure preparing request")
 	}
@@ -775,14 +800,14 @@ func (client VirtualMachinesClient) Restart(resourceGroupName string, vmName str
 
 	result, err = client.RestartResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Restart", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Restart", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // RestartPreparer prepares the Restart request.
-func (client VirtualMachinesClient) RestartPreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) RestartPreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -793,7 +818,7 @@ func (client VirtualMachinesClient) RestartPreparer(resourceGroupName string, vm
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -805,7 +830,9 @@ func (client VirtualMachinesClient) RestartPreparer(resourceGroupName string, vm
 // RestartSender sends the Restart request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) RestartSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // RestartResponder handles the response to the Restart request. The method always
@@ -820,12 +847,15 @@ func (client VirtualMachinesClient) RestartResponder(resp *http.Response) (resul
 	return
 }
 
-// Start the operation to start a virtual machine.
+// Start the operation to start a virtual machine. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Start(resourceGroupName string, vmName string) (result autorest.Response, ae error) {
-	req, err := client.StartPreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) Start(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StartPreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Start", nil, "Failure preparing request")
 	}
@@ -838,14 +868,14 @@ func (client VirtualMachinesClient) Start(resourceGroupName string, vmName strin
 
 	result, err = client.StartResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Start", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Start", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // StartPreparer prepares the Start request.
-func (client VirtualMachinesClient) StartPreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) StartPreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -856,7 +886,7 @@ func (client VirtualMachinesClient) StartPreparer(resourceGroupName string, vmNa
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -868,7 +898,9 @@ func (client VirtualMachinesClient) StartPreparer(resourceGroupName string, vmNa
 // StartSender sends the Start request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachinesClient) StartSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StartResponder handles the response to the Start request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinescalesets.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinescalesets.go
@@ -43,33 +43,35 @@ func NewVirtualMachineScaleSetsClientWithBaseURI(baseURI string, subscriptionID 
 }
 
 // CreateOrUpdate the operation to create or update a virtual machine scale
-// set.
+// set. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. name is parameters
 // supplied to the Create Virtual Machine Scale Set operation. parameters is
 // parameters supplied to the Create Virtual Machine Scale Set operation.
-func (client VirtualMachineScaleSetsClient) CreateOrUpdate(resourceGroupName string, name string, parameters VirtualMachineScaleSet) (result VirtualMachineScaleSet, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, name, parameters)
+func (client VirtualMachineScaleSetsClient) CreateOrUpdate(resourceGroupName string, name string, parameters VirtualMachineScaleSet, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, name, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualMachineScaleSetsClient) CreateOrUpdatePreparer(resourceGroupName string, name string, parameters VirtualMachineScaleSet) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) CreateOrUpdatePreparer(resourceGroupName string, name string, parameters VirtualMachineScaleSet, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"name":              url.QueryEscape(name),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -80,7 +82,7 @@ func (client VirtualMachineScaleSetsClient) CreateOrUpdatePreparer(resourceGroup
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -93,30 +95,33 @@ func (client VirtualMachineScaleSetsClient) CreateOrUpdatePreparer(resourceGroup
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineScaleSetsClient) CreateOrUpdateResponder(resp *http.Response) (result VirtualMachineScaleSet, err error) {
+func (client VirtualMachineScaleSetsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Deallocate the operation to deallocate virtual machines in a virtual
-// machine scale set.
+// machine scale set. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) Deallocate(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (result autorest.Response, ae error) {
-	req, err := client.DeallocatePreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) Deallocate(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeallocatePreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Deallocate", nil, "Failure preparing request")
 	}
@@ -129,14 +134,14 @@ func (client VirtualMachineScaleSetsClient) Deallocate(resourceGroupName string,
 
 	result, err = client.DeallocateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Deallocate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Deallocate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeallocatePreparer prepares the Deallocate request.
-func (client VirtualMachineScaleSetsClient) DeallocatePreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) DeallocatePreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -158,13 +163,15 @@ func (client VirtualMachineScaleSetsClient) DeallocatePreparer(resourceGroupName
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithJSON(vmInstanceIDs))
 	}
-	return preparer.Prepare(&http.Request{})
+	return preparer.Prepare(&http.Request{Cancel: cancel})
 }
 
 // DeallocateSender sends the Deallocate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) DeallocateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeallocateResponder handles the response to the Deallocate request. The method always
@@ -179,12 +186,15 @@ func (client VirtualMachineScaleSetsClient) DeallocateResponder(resp *http.Respo
 	return
 }
 
-// Delete the operation to delete a virtual machine scale set.
+// Delete the operation to delete a virtual machine scale set. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set.
-func (client VirtualMachineScaleSetsClient) Delete(resourceGroupName string, vmScaleSetName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, vmScaleSetName)
+func (client VirtualMachineScaleSetsClient) Delete(resourceGroupName string, vmScaleSetName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, vmScaleSetName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -197,14 +207,14 @@ func (client VirtualMachineScaleSetsClient) Delete(resourceGroupName string, vmS
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualMachineScaleSetsClient) DeletePreparer(resourceGroupName string, vmScaleSetName string) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) DeletePreparer(resourceGroupName string, vmScaleSetName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -215,7 +225,7 @@ func (client VirtualMachineScaleSetsClient) DeletePreparer(resourceGroupName str
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -227,7 +237,9 @@ func (client VirtualMachineScaleSetsClient) DeletePreparer(resourceGroupName str
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -243,13 +255,15 @@ func (client VirtualMachineScaleSetsClient) DeleteResponder(resp *http.Response)
 }
 
 // DeleteInstances the operation to delete virtual machines in a virtual
-// machine scale set.
+// machine scale set. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) DeleteInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (result autorest.Response, ae error) {
-	req, err := client.DeleteInstancesPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) DeleteInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeleteInstancesPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "DeleteInstances", nil, "Failure preparing request")
 	}
@@ -262,14 +276,14 @@ func (client VirtualMachineScaleSetsClient) DeleteInstances(resourceGroupName st
 
 	result, err = client.DeleteInstancesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "DeleteInstances", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "DeleteInstances", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeleteInstancesPreparer prepares the DeleteInstances request.
-func (client VirtualMachineScaleSetsClient) DeleteInstancesPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) DeleteInstancesPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -280,7 +294,7 @@ func (client VirtualMachineScaleSetsClient) DeleteInstancesPreparer(resourceGrou
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -293,7 +307,9 @@ func (client VirtualMachineScaleSetsClient) DeleteInstancesPreparer(resourceGrou
 // DeleteInstancesSender sends the DeleteInstances request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) DeleteInstancesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteInstancesResponder handles the response to the DeleteInstances request. The method always
@@ -312,7 +328,7 @@ func (client VirtualMachineScaleSetsClient) DeleteInstancesResponder(resp *http.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set.
-func (client VirtualMachineScaleSetsClient) Get(resourceGroupName string, vmScaleSetName string) (result VirtualMachineScaleSet, ae error) {
+func (client VirtualMachineScaleSetsClient) Get(resourceGroupName string, vmScaleSetName string) (result VirtualMachineScaleSet, err error) {
 	req, err := client.GetPreparer(resourceGroupName, vmScaleSetName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Get", nil, "Failure preparing request")
@@ -326,7 +342,7 @@ func (client VirtualMachineScaleSetsClient) Get(resourceGroupName string, vmScal
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -356,7 +372,7 @@ func (client VirtualMachineScaleSetsClient) GetPreparer(resourceGroupName string
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -377,7 +393,7 @@ func (client VirtualMachineScaleSetsClient) GetResponder(resp *http.Response) (r
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set.
-func (client VirtualMachineScaleSetsClient) GetInstanceView(resourceGroupName string, vmScaleSetName string) (result VirtualMachineScaleSetInstanceView, ae error) {
+func (client VirtualMachineScaleSetsClient) GetInstanceView(resourceGroupName string, vmScaleSetName string) (result VirtualMachineScaleSetInstanceView, err error) {
 	req, err := client.GetInstanceViewPreparer(resourceGroupName, vmScaleSetName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "GetInstanceView", nil, "Failure preparing request")
@@ -391,7 +407,7 @@ func (client VirtualMachineScaleSetsClient) GetInstanceView(resourceGroupName st
 
 	result, err = client.GetInstanceViewResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "GetInstanceView", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "GetInstanceView", resp, "Failure responding to request")
 	}
 
 	return
@@ -421,7 +437,7 @@ func (client VirtualMachineScaleSetsClient) GetInstanceViewPreparer(resourceGrou
 // GetInstanceViewSender sends the GetInstanceView request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) GetInstanceViewSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetInstanceViewResponder handles the response to the GetInstanceView request. The method always
@@ -441,7 +457,7 @@ func (client VirtualMachineScaleSetsClient) GetInstanceViewResponder(resp *http.
 // group.
 //
 // resourceGroupName is the name of the resource group.
-func (client VirtualMachineScaleSetsClient) List(resourceGroupName string) (result VirtualMachineScaleSetListResult, ae error) {
+func (client VirtualMachineScaleSetsClient) List(resourceGroupName string) (result VirtualMachineScaleSetListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "List", nil, "Failure preparing request")
@@ -455,7 +471,7 @@ func (client VirtualMachineScaleSetsClient) List(resourceGroupName string) (resu
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -484,7 +500,7 @@ func (client VirtualMachineScaleSetsClient) ListPreparer(resourceGroupName strin
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -501,7 +517,7 @@ func (client VirtualMachineScaleSetsClient) ListResponder(resp *http.Response) (
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client VirtualMachineScaleSetsClient) ListNextResults(lastResults VirtualMachineScaleSetListResult) (result VirtualMachineScaleSetListResult, ae error) {
+func (client VirtualMachineScaleSetsClient) ListNextResults(lastResults VirtualMachineScaleSetListResult) (result VirtualMachineScaleSetListResult, err error) {
 	req, err := lastResults.VirtualMachineScaleSetListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "List", nil, "Failure preparing next results request request")
@@ -518,7 +534,7 @@ func (client VirtualMachineScaleSetsClient) ListNextResults(lastResults VirtualM
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -528,7 +544,7 @@ func (client VirtualMachineScaleSetsClient) ListNextResults(lastResults VirtualM
 // Use nextLink property in the response to get the next page of Virtual
 // Machine Scale Sets. Do this till nextLink is not null to fetch all the
 // Virtual Machine Scale Sets.
-func (client VirtualMachineScaleSetsClient) ListAll() (result VirtualMachineScaleSetListWithLinkResult, ae error) {
+func (client VirtualMachineScaleSetsClient) ListAll() (result VirtualMachineScaleSetListWithLinkResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListAll", nil, "Failure preparing request")
@@ -542,7 +558,7 @@ func (client VirtualMachineScaleSetsClient) ListAll() (result VirtualMachineScal
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -570,7 +586,7 @@ func (client VirtualMachineScaleSetsClient) ListAllPreparer() (*http.Request, er
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -587,7 +603,7 @@ func (client VirtualMachineScaleSetsClient) ListAllResponder(resp *http.Response
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client VirtualMachineScaleSetsClient) ListAllNextResults(lastResults VirtualMachineScaleSetListWithLinkResult) (result VirtualMachineScaleSetListWithLinkResult, ae error) {
+func (client VirtualMachineScaleSetsClient) ListAllNextResults(lastResults VirtualMachineScaleSetListWithLinkResult) (result VirtualMachineScaleSetListWithLinkResult, err error) {
 	req, err := lastResults.VirtualMachineScaleSetListWithLinkResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListAll", nil, "Failure preparing next results request request")
@@ -604,7 +620,7 @@ func (client VirtualMachineScaleSetsClient) ListAllNextResults(lastResults Virtu
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -615,7 +631,7 @@ func (client VirtualMachineScaleSetsClient) ListAllNextResults(lastResults Virtu
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set.
-func (client VirtualMachineScaleSetsClient) ListSkus(resourceGroupName string, vmScaleSetName string) (result VirtualMachineScaleSetListSkusResult, ae error) {
+func (client VirtualMachineScaleSetsClient) ListSkus(resourceGroupName string, vmScaleSetName string) (result VirtualMachineScaleSetListSkusResult, err error) {
 	req, err := client.ListSkusPreparer(resourceGroupName, vmScaleSetName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListSkus", nil, "Failure preparing request")
@@ -629,7 +645,7 @@ func (client VirtualMachineScaleSetsClient) ListSkus(resourceGroupName string, v
 
 	result, err = client.ListSkusResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListSkus", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListSkus", resp, "Failure responding to request")
 	}
 
 	return
@@ -659,7 +675,7 @@ func (client VirtualMachineScaleSetsClient) ListSkusPreparer(resourceGroupName s
 // ListSkusSender sends the ListSkus request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) ListSkusSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListSkusResponder handles the response to the ListSkus request. The method always
@@ -676,7 +692,7 @@ func (client VirtualMachineScaleSetsClient) ListSkusResponder(resp *http.Respons
 }
 
 // ListSkusNextResults retrieves the next set of results, if any.
-func (client VirtualMachineScaleSetsClient) ListSkusNextResults(lastResults VirtualMachineScaleSetListSkusResult) (result VirtualMachineScaleSetListSkusResult, ae error) {
+func (client VirtualMachineScaleSetsClient) ListSkusNextResults(lastResults VirtualMachineScaleSetListSkusResult) (result VirtualMachineScaleSetListSkusResult, err error) {
 	req, err := lastResults.VirtualMachineScaleSetListSkusResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListSkus", nil, "Failure preparing next results request request")
@@ -693,20 +709,22 @@ func (client VirtualMachineScaleSetsClient) ListSkusNextResults(lastResults Virt
 
 	result, err = client.ListSkusResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListSkus", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "ListSkus", resp, "Failure responding to next results request request")
 	}
 
 	return
 }
 
 // PowerOff the operation to power off (stop) virtual machines in a virtual
-// machine scale set.
+// machine scale set. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) PowerOff(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (result autorest.Response, ae error) {
-	req, err := client.PowerOffPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) PowerOff(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.PowerOffPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "PowerOff", nil, "Failure preparing request")
 	}
@@ -719,14 +737,14 @@ func (client VirtualMachineScaleSetsClient) PowerOff(resourceGroupName string, v
 
 	result, err = client.PowerOffResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "PowerOff", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "PowerOff", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // PowerOffPreparer prepares the PowerOff request.
-func (client VirtualMachineScaleSetsClient) PowerOffPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) PowerOffPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -748,13 +766,15 @@ func (client VirtualMachineScaleSetsClient) PowerOffPreparer(resourceGroupName s
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithJSON(vmInstanceIDs))
 	}
-	return preparer.Prepare(&http.Request{})
+	return preparer.Prepare(&http.Request{Cancel: cancel})
 }
 
 // PowerOffSender sends the PowerOff request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) PowerOffSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // PowerOffResponder handles the response to the PowerOff request. The method always
@@ -770,13 +790,15 @@ func (client VirtualMachineScaleSetsClient) PowerOffResponder(resp *http.Respons
 }
 
 // Restart the operation to restart virtual machines in a virtual machine
-// scale set.
+// scale set. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) Restart(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (result autorest.Response, ae error) {
-	req, err := client.RestartPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) Restart(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.RestartPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Restart", nil, "Failure preparing request")
 	}
@@ -789,14 +811,14 @@ func (client VirtualMachineScaleSetsClient) Restart(resourceGroupName string, vm
 
 	result, err = client.RestartResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Restart", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Restart", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // RestartPreparer prepares the Restart request.
-func (client VirtualMachineScaleSetsClient) RestartPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) RestartPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -818,13 +840,15 @@ func (client VirtualMachineScaleSetsClient) RestartPreparer(resourceGroupName st
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithJSON(vmInstanceIDs))
 	}
-	return preparer.Prepare(&http.Request{})
+	return preparer.Prepare(&http.Request{Cancel: cancel})
 }
 
 // RestartSender sends the Restart request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) RestartSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // RestartResponder handles the response to the Restart request. The method always
@@ -840,13 +864,15 @@ func (client VirtualMachineScaleSetsClient) RestartResponder(resp *http.Response
 }
 
 // Start the operation to start virtual machines in a virtual machine scale
-// set.
+// set. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) Start(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (result autorest.Response, ae error) {
-	req, err := client.StartPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) Start(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StartPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Start", nil, "Failure preparing request")
 	}
@@ -859,14 +885,14 @@ func (client VirtualMachineScaleSetsClient) Start(resourceGroupName string, vmSc
 
 	result, err = client.StartResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Start", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Start", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // StartPreparer prepares the Start request.
-func (client VirtualMachineScaleSetsClient) StartPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) StartPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -888,13 +914,15 @@ func (client VirtualMachineScaleSetsClient) StartPreparer(resourceGroupName stri
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithJSON(vmInstanceIDs))
 	}
-	return preparer.Prepare(&http.Request{})
+	return preparer.Prepare(&http.Request{Cancel: cancel})
 }
 
 // StartSender sends the Start request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) StartSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StartResponder handles the response to the Start request. The method always
@@ -910,13 +938,15 @@ func (client VirtualMachineScaleSetsClient) StartResponder(resp *http.Response) 
 }
 
 // UpdateInstances the operation to manually upgrade virtual machines in a
-// virtual machine scale set.
+// virtual machine scale set. This method may poll for completion. Polling
+// can be canceled by passing the cancel channel argument. The channel will
+// be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) UpdateInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (result autorest.Response, ae error) {
-	req, err := client.UpdateInstancesPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) UpdateInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.UpdateInstancesPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "UpdateInstances", nil, "Failure preparing request")
 	}
@@ -929,14 +959,14 @@ func (client VirtualMachineScaleSetsClient) UpdateInstances(resourceGroupName st
 
 	result, err = client.UpdateInstancesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "UpdateInstances", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "UpdateInstances", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // UpdateInstancesPreparer prepares the UpdateInstances request.
-func (client VirtualMachineScaleSetsClient) UpdateInstancesPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) UpdateInstancesPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -947,7 +977,7 @@ func (client VirtualMachineScaleSetsClient) UpdateInstancesPreparer(resourceGrou
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -960,7 +990,9 @@ func (client VirtualMachineScaleSetsClient) UpdateInstancesPreparer(resourceGrou
 // UpdateInstancesSender sends the UpdateInstances request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetsClient) UpdateInstancesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // UpdateInstancesResponder handles the response to the UpdateInstances request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinescalesetvms.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinescalesetvms.go
@@ -42,13 +42,16 @@ func NewVirtualMachineScaleSetVMsClientWithBaseURI(baseURI string, subscriptionI
 	return VirtualMachineScaleSetVMsClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// Deallocate the operation to deallocate a virtual machine scale set.
+// Deallocate the operation to deallocate a virtual machine scale set. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Deallocate(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, ae error) {
-	req, err := client.DeallocatePreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) Deallocate(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeallocatePreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Deallocate", nil, "Failure preparing request")
 	}
@@ -61,14 +64,14 @@ func (client VirtualMachineScaleSetVMsClient) Deallocate(resourceGroupName strin
 
 	result, err = client.DeallocateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Deallocate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Deallocate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeallocatePreparer prepares the Deallocate request.
-func (client VirtualMachineScaleSetVMsClient) DeallocatePreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) DeallocatePreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -80,7 +83,7 @@ func (client VirtualMachineScaleSetVMsClient) DeallocatePreparer(resourceGroupNa
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -92,7 +95,9 @@ func (client VirtualMachineScaleSetVMsClient) DeallocatePreparer(resourceGroupNa
 // DeallocateSender sends the Deallocate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetVMsClient) DeallocateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeallocateResponder handles the response to the Deallocate request. The method always
@@ -107,13 +112,16 @@ func (client VirtualMachineScaleSetVMsClient) DeallocateResponder(resp *http.Res
 	return
 }
 
-// Delete the operation to delete a virtual machine scale set.
+// Delete the operation to delete a virtual machine scale set. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Delete(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) Delete(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -126,14 +134,14 @@ func (client VirtualMachineScaleSetVMsClient) Delete(resourceGroupName string, v
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualMachineScaleSetVMsClient) DeletePreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) DeletePreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -145,7 +153,7 @@ func (client VirtualMachineScaleSetVMsClient) DeletePreparer(resourceGroupName s
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -157,7 +165,9 @@ func (client VirtualMachineScaleSetVMsClient) DeletePreparer(resourceGroupName s
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetVMsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -177,7 +187,7 @@ func (client VirtualMachineScaleSetVMsClient) DeleteResponder(resp *http.Respons
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Get(resourceGroupName string, vmScaleSetName string, instanceID string) (result VirtualMachineScaleSetVM, ae error) {
+func (client VirtualMachineScaleSetVMsClient) Get(resourceGroupName string, vmScaleSetName string, instanceID string) (result VirtualMachineScaleSetVM, err error) {
 	req, err := client.GetPreparer(resourceGroupName, vmScaleSetName, instanceID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Get", nil, "Failure preparing request")
@@ -191,7 +201,7 @@ func (client VirtualMachineScaleSetVMsClient) Get(resourceGroupName string, vmSc
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -222,7 +232,7 @@ func (client VirtualMachineScaleSetVMsClient) GetPreparer(resourceGroupName stri
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetVMsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -244,7 +254,7 @@ func (client VirtualMachineScaleSetVMsClient) GetResponder(resp *http.Response) 
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) GetInstanceView(resourceGroupName string, vmScaleSetName string, instanceID string) (result VirtualMachineScaleSetVMInstanceView, ae error) {
+func (client VirtualMachineScaleSetVMsClient) GetInstanceView(resourceGroupName string, vmScaleSetName string, instanceID string) (result VirtualMachineScaleSetVMInstanceView, err error) {
 	req, err := client.GetInstanceViewPreparer(resourceGroupName, vmScaleSetName, instanceID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "GetInstanceView", nil, "Failure preparing request")
@@ -258,7 +268,7 @@ func (client VirtualMachineScaleSetVMsClient) GetInstanceView(resourceGroupName 
 
 	result, err = client.GetInstanceViewResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "GetInstanceView", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "GetInstanceView", resp, "Failure responding to request")
 	}
 
 	return
@@ -289,7 +299,7 @@ func (client VirtualMachineScaleSetVMsClient) GetInstanceViewPreparer(resourceGr
 // GetInstanceViewSender sends the GetInstanceView request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetVMsClient) GetInstanceViewSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetInstanceViewResponder handles the response to the GetInstanceView request. The method always
@@ -312,7 +322,7 @@ func (client VirtualMachineScaleSetVMsClient) GetInstanceViewResponder(resp *htt
 // filter is the filter to apply on the operation. selectParameter is the
 // list parameters. expand is the expand expression to apply on the
 // operation.
-func (client VirtualMachineScaleSetVMsClient) List(resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) (result VirtualMachineScaleSetVMListResult, ae error) {
+func (client VirtualMachineScaleSetVMsClient) List(resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) (result VirtualMachineScaleSetVMListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName, virtualMachineScaleSetName, filter, selectParameter, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "List", nil, "Failure preparing request")
@@ -326,7 +336,7 @@ func (client VirtualMachineScaleSetVMsClient) List(resourceGroupName string, vir
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -365,7 +375,7 @@ func (client VirtualMachineScaleSetVMsClient) ListPreparer(resourceGroupName str
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetVMsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -382,7 +392,7 @@ func (client VirtualMachineScaleSetVMsClient) ListResponder(resp *http.Response)
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client VirtualMachineScaleSetVMsClient) ListNextResults(lastResults VirtualMachineScaleSetVMListResult) (result VirtualMachineScaleSetVMListResult, ae error) {
+func (client VirtualMachineScaleSetVMsClient) ListNextResults(lastResults VirtualMachineScaleSetVMListResult) (result VirtualMachineScaleSetVMListResult, err error) {
 	req, err := lastResults.VirtualMachineScaleSetVMListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "List", nil, "Failure preparing next results request request")
@@ -399,19 +409,22 @@ func (client VirtualMachineScaleSetVMsClient) ListNextResults(lastResults Virtua
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
 }
 
 // PowerOff the operation to power off (stop) a virtual machine scale set.
+// This method may poll for completion. Polling can be canceled by passing
+// the cancel channel argument. The channel will be used to cancel polling
+// and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) PowerOff(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, ae error) {
-	req, err := client.PowerOffPreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) PowerOff(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.PowerOffPreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "PowerOff", nil, "Failure preparing request")
 	}
@@ -424,14 +437,14 @@ func (client VirtualMachineScaleSetVMsClient) PowerOff(resourceGroupName string,
 
 	result, err = client.PowerOffResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "PowerOff", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "PowerOff", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // PowerOffPreparer prepares the PowerOff request.
-func (client VirtualMachineScaleSetVMsClient) PowerOffPreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) PowerOffPreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -443,7 +456,7 @@ func (client VirtualMachineScaleSetVMsClient) PowerOffPreparer(resourceGroupName
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -455,7 +468,9 @@ func (client VirtualMachineScaleSetVMsClient) PowerOffPreparer(resourceGroupName
 // PowerOffSender sends the PowerOff request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetVMsClient) PowerOffSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // PowerOffResponder handles the response to the PowerOff request. The method always
@@ -470,13 +485,16 @@ func (client VirtualMachineScaleSetVMsClient) PowerOffResponder(resp *http.Respo
 	return
 }
 
-// Restart the operation to restart a virtual machine scale set.
+// Restart the operation to restart a virtual machine scale set. This method
+// may poll for completion. Polling can be canceled by passing the cancel
+// channel argument. The channel will be used to cancel polling and any
+// outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Restart(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, ae error) {
-	req, err := client.RestartPreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) Restart(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.RestartPreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Restart", nil, "Failure preparing request")
 	}
@@ -489,14 +507,14 @@ func (client VirtualMachineScaleSetVMsClient) Restart(resourceGroupName string, 
 
 	result, err = client.RestartResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Restart", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Restart", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // RestartPreparer prepares the Restart request.
-func (client VirtualMachineScaleSetVMsClient) RestartPreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) RestartPreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -508,7 +526,7 @@ func (client VirtualMachineScaleSetVMsClient) RestartPreparer(resourceGroupName 
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -520,7 +538,9 @@ func (client VirtualMachineScaleSetVMsClient) RestartPreparer(resourceGroupName 
 // RestartSender sends the Restart request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetVMsClient) RestartSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // RestartResponder handles the response to the Restart request. The method always
@@ -535,13 +555,16 @@ func (client VirtualMachineScaleSetVMsClient) RestartResponder(resp *http.Respon
 	return
 }
 
-// Start the operation to start a virtual machine scale set.
+// Start the operation to start a virtual machine scale set. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Start(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, ae error) {
-	req, err := client.StartPreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) Start(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StartPreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Start", nil, "Failure preparing request")
 	}
@@ -554,14 +577,14 @@ func (client VirtualMachineScaleSetVMsClient) Start(resourceGroupName string, vm
 
 	result, err = client.StartResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Start", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Start", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // StartPreparer prepares the Start request.
-func (client VirtualMachineScaleSetVMsClient) StartPreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) StartPreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -573,7 +596,7 @@ func (client VirtualMachineScaleSetVMsClient) StartPreparer(resourceGroupName st
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -585,7 +608,9 @@ func (client VirtualMachineScaleSetVMsClient) StartPreparer(resourceGroupName st
 // StartSender sends the Start request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineScaleSetVMsClient) StartSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StartResponder handles the response to the Start request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinesizes.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinesizes.go
@@ -45,7 +45,7 @@ func NewVirtualMachineSizesClientWithBaseURI(baseURI string, subscriptionID stri
 // List lists virtual-machine-sizes available in a location for a subscription.
 //
 // location is the location upon which virtual-machine-sizes is queried.
-func (client VirtualMachineSizesClient) List(location string) (result VirtualMachineSizeListResult, ae error) {
+func (client VirtualMachineSizesClient) List(location string) (result VirtualMachineSizeListResult, err error) {
 	req, err := client.ListPreparer(location)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineSizesClient", "List", nil, "Failure preparing request")
@@ -59,7 +59,7 @@ func (client VirtualMachineSizesClient) List(location string) (result VirtualMac
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineSizesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineSizesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -88,7 +88,7 @@ func (client VirtualMachineSizesClient) ListPreparer(location string) (*http.Req
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualMachineSizesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -105,7 +105,7 @@ func (client VirtualMachineSizesClient) ListResponder(resp *http.Response) (resu
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client VirtualMachineSizesClient) ListNextResults(lastResults VirtualMachineSizeListResult) (result VirtualMachineSizeListResult, ae error) {
+func (client VirtualMachineSizesClient) ListNextResults(lastResults VirtualMachineSizeListResult) (result VirtualMachineSizeListResult, err error) {
 	req, err := lastResults.VirtualMachineSizeListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineSizesClient", "List", nil, "Failure preparing next results request request")
@@ -122,7 +122,7 @@ func (client VirtualMachineSizesClient) ListNextResults(lastResults VirtualMachi
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "compute/VirtualMachineSizesClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "compute/VirtualMachineSizesClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/applicationgateways.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/applicationgateways.go
@@ -47,33 +47,35 @@ func NewApplicationGatewaysClientWithBaseURI(baseURI string, subscriptionID stri
 }
 
 // CreateOrUpdate the Put ApplicationGateway operation creates/updates a
-// ApplicationGateway
+// ApplicationGateway This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the ApplicationGateway. parameters is parameters supplied
 // to the create/delete ApplicationGateway operation
-func (client ApplicationGatewaysClient) CreateOrUpdate(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (result ApplicationGateway, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, applicationGatewayName, parameters)
+func (client ApplicationGatewaysClient) CreateOrUpdate(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, applicationGatewayName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ApplicationGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (*http.Request, error) {
+func (client ApplicationGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"applicationGatewayName": url.QueryEscape(applicationGatewayName),
 		"resourceGroupName":      url.QueryEscape(resourceGroupName),
@@ -84,7 +86,7 @@ func (client ApplicationGatewaysClient) CreateOrUpdatePreparer(resourceGroupName
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -97,29 +99,32 @@ func (client ApplicationGatewaysClient) CreateOrUpdatePreparer(resourceGroupName
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client ApplicationGatewaysClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client ApplicationGatewaysClient) CreateOrUpdateResponder(resp *http.Response) (result ApplicationGateway, err error) {
+func (client ApplicationGatewaysClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the delete applicationgateway operation deletes the specified
-// applicationgateway.
+// applicationgateway. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the applicationgateway.
-func (client ApplicationGatewaysClient) Delete(resourceGroupName string, applicationGatewayName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, applicationGatewayName)
+func (client ApplicationGatewaysClient) Delete(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, applicationGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Delete", nil, "Failure preparing request")
 	}
@@ -132,14 +137,14 @@ func (client ApplicationGatewaysClient) Delete(resourceGroupName string, applica
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client ApplicationGatewaysClient) DeletePreparer(resourceGroupName string, applicationGatewayName string) (*http.Request, error) {
+func (client ApplicationGatewaysClient) DeletePreparer(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"applicationGatewayName": url.QueryEscape(applicationGatewayName),
 		"resourceGroupName":      url.QueryEscape(resourceGroupName),
@@ -150,7 +155,7 @@ func (client ApplicationGatewaysClient) DeletePreparer(resourceGroupName string,
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -162,7 +167,9 @@ func (client ApplicationGatewaysClient) DeletePreparer(resourceGroupName string,
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client ApplicationGatewaysClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -182,7 +189,7 @@ func (client ApplicationGatewaysClient) DeleteResponder(resp *http.Response) (re
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the applicationgateway.
-func (client ApplicationGatewaysClient) Get(resourceGroupName string, applicationGatewayName string) (result ApplicationGateway, ae error) {
+func (client ApplicationGatewaysClient) Get(resourceGroupName string, applicationGatewayName string) (result ApplicationGateway, err error) {
 	req, err := client.GetPreparer(resourceGroupName, applicationGatewayName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Get", nil, "Failure preparing request")
@@ -196,7 +203,7 @@ func (client ApplicationGatewaysClient) Get(resourceGroupName string, applicatio
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -226,7 +233,7 @@ func (client ApplicationGatewaysClient) GetPreparer(resourceGroupName string, ap
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client ApplicationGatewaysClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -246,7 +253,7 @@ func (client ApplicationGatewaysClient) GetResponder(resp *http.Response) (resul
 // applicationgateways in a resource group.
 //
 // resourceGroupName is the name of the resource group.
-func (client ApplicationGatewaysClient) List(resourceGroupName string) (result ApplicationGatewayListResult, ae error) {
+func (client ApplicationGatewaysClient) List(resourceGroupName string) (result ApplicationGatewayListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "List", nil, "Failure preparing request")
@@ -260,7 +267,7 @@ func (client ApplicationGatewaysClient) List(resourceGroupName string) (result A
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -289,7 +296,7 @@ func (client ApplicationGatewaysClient) ListPreparer(resourceGroupName string) (
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ApplicationGatewaysClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -306,7 +313,7 @@ func (client ApplicationGatewaysClient) ListResponder(resp *http.Response) (resu
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ApplicationGatewaysClient) ListNextResults(lastResults ApplicationGatewayListResult) (result ApplicationGatewayListResult, ae error) {
+func (client ApplicationGatewaysClient) ListNextResults(lastResults ApplicationGatewayListResult) (result ApplicationGatewayListResult, err error) {
 	req, err := lastResults.ApplicationGatewayListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "List", nil, "Failure preparing next results request request")
@@ -323,7 +330,7 @@ func (client ApplicationGatewaysClient) ListNextResults(lastResults ApplicationG
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -331,7 +338,7 @@ func (client ApplicationGatewaysClient) ListNextResults(lastResults ApplicationG
 
 // ListAll the List applicationgateway opertion retrieves all the
 // applicationgateways in a subscription.
-func (client ApplicationGatewaysClient) ListAll() (result ApplicationGatewayListResult, ae error) {
+func (client ApplicationGatewaysClient) ListAll() (result ApplicationGatewayListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "ListAll", nil, "Failure preparing request")
@@ -345,7 +352,7 @@ func (client ApplicationGatewaysClient) ListAll() (result ApplicationGatewayList
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -373,7 +380,7 @@ func (client ApplicationGatewaysClient) ListAllPreparer() (*http.Request, error)
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client ApplicationGatewaysClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -390,7 +397,7 @@ func (client ApplicationGatewaysClient) ListAllResponder(resp *http.Response) (r
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client ApplicationGatewaysClient) ListAllNextResults(lastResults ApplicationGatewayListResult) (result ApplicationGatewayListResult, ae error) {
+func (client ApplicationGatewaysClient) ListAllNextResults(lastResults ApplicationGatewayListResult) (result ApplicationGatewayListResult, err error) {
 	req, err := lastResults.ApplicationGatewayListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "ListAll", nil, "Failure preparing next results request request")
@@ -407,19 +414,22 @@ func (client ApplicationGatewaysClient) ListAllNextResults(lastResults Applicati
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return
 }
 
 // Start the Start ApplicationGateway operation starts application gatewayin
-// the specified resource group through Network resource provider.
+// the specified resource group through Network resource provider. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the application gateway.
-func (client ApplicationGatewaysClient) Start(resourceGroupName string, applicationGatewayName string) (result autorest.Response, ae error) {
-	req, err := client.StartPreparer(resourceGroupName, applicationGatewayName)
+func (client ApplicationGatewaysClient) Start(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StartPreparer(resourceGroupName, applicationGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Start", nil, "Failure preparing request")
 	}
@@ -432,14 +442,14 @@ func (client ApplicationGatewaysClient) Start(resourceGroupName string, applicat
 
 	result, err = client.StartResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Start", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Start", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // StartPreparer prepares the Start request.
-func (client ApplicationGatewaysClient) StartPreparer(resourceGroupName string, applicationGatewayName string) (*http.Request, error) {
+func (client ApplicationGatewaysClient) StartPreparer(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"applicationGatewayName": url.QueryEscape(applicationGatewayName),
 		"resourceGroupName":      url.QueryEscape(resourceGroupName),
@@ -450,7 +460,7 @@ func (client ApplicationGatewaysClient) StartPreparer(resourceGroupName string, 
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -462,7 +472,9 @@ func (client ApplicationGatewaysClient) StartPreparer(resourceGroupName string, 
 // StartSender sends the Start request. The method will close the
 // http.Response Body if it receives an error.
 func (client ApplicationGatewaysClient) StartSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StartResponder handles the response to the Start request. The method always
@@ -478,12 +490,15 @@ func (client ApplicationGatewaysClient) StartResponder(resp *http.Response) (res
 }
 
 // Stop the STOP ApplicationGateway operation stops application gatewayin the
-// specified resource group through Network resource provider.
+// specified resource group through Network resource provider. This method
+// may poll for completion. Polling can be canceled by passing the cancel
+// channel argument. The channel will be used to cancel polling and any
+// outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the application gateway.
-func (client ApplicationGatewaysClient) Stop(resourceGroupName string, applicationGatewayName string) (result autorest.Response, ae error) {
-	req, err := client.StopPreparer(resourceGroupName, applicationGatewayName)
+func (client ApplicationGatewaysClient) Stop(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StopPreparer(resourceGroupName, applicationGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Stop", nil, "Failure preparing request")
 	}
@@ -496,14 +511,14 @@ func (client ApplicationGatewaysClient) Stop(resourceGroupName string, applicati
 
 	result, err = client.StopResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Stop", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Stop", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // StopPreparer prepares the Stop request.
-func (client ApplicationGatewaysClient) StopPreparer(resourceGroupName string, applicationGatewayName string) (*http.Request, error) {
+func (client ApplicationGatewaysClient) StopPreparer(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"applicationGatewayName": url.QueryEscape(applicationGatewayName),
 		"resourceGroupName":      url.QueryEscape(resourceGroupName),
@@ -514,7 +529,7 @@ func (client ApplicationGatewaysClient) StopPreparer(resourceGroupName string, a
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -526,7 +541,9 @@ func (client ApplicationGatewaysClient) StopPreparer(resourceGroupName string, a
 // StopSender sends the Stop request. The method will close the
 // http.Response Body if it receives an error.
 func (client ApplicationGatewaysClient) StopSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StopResponder handles the response to the Stop request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/client.go
@@ -4,7 +4,7 @@
 // The Microsoft Azure Network management API provides a RESTful set of web
 // services that interact with Microsoft Azure Networks service to manage
 // your network resrources. The API has entities that capture the
-// relationship between an end user and the Microsoft Azure Networks service..
+// relationship between an end user and the Microsoft Azure Networks service.
 package network
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.
@@ -67,7 +67,7 @@ func NewWithBaseURI(baseURI string, subscriptionID string) ManagementClient {
 // location is the location of the domain name domainNameLabel is the domain
 // name to be verified. It must conform to the following regular expression:
 // ^[a-z][a-z0-9-]{1,61}[a-z0-9]$.
-func (client ManagementClient) CheckDNSNameAvailability(location string, domainNameLabel string) (result DNSNameAvailabilityResult, ae error) {
+func (client ManagementClient) CheckDNSNameAvailability(location string, domainNameLabel string) (result DNSNameAvailabilityResult, err error) {
 	req, err := client.CheckDNSNameAvailabilityPreparer(location, domainNameLabel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ManagementClient", "CheckDNSNameAvailability", nil, "Failure preparing request")
@@ -81,7 +81,7 @@ func (client ManagementClient) CheckDNSNameAvailability(location string, domainN
 
 	result, err = client.CheckDNSNameAvailabilityResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ManagementClient", "CheckDNSNameAvailability", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ManagementClient", "CheckDNSNameAvailability", resp, "Failure responding to request")
 	}
 
 	return
@@ -113,7 +113,7 @@ func (client ManagementClient) CheckDNSNameAvailabilityPreparer(location string,
 // CheckDNSNameAvailabilitySender sends the CheckDNSNameAvailability request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) CheckDNSNameAvailabilitySender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CheckDNSNameAvailabilityResponder handles the response to the CheckDNSNameAvailability request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuitauthorizations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuitauthorizations.go
@@ -47,34 +47,37 @@ func NewExpressRouteCircuitAuthorizationsClientWithBaseURI(baseURI string, subsc
 }
 
 // CreateOrUpdate the Put Authorization operation creates/updates an
-// authorization in thespecified ExpressRouteCircuits
+// authorization in thespecified ExpressRouteCircuits This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. authorizationName is the name of the
 // authorization. authorizationParameters is parameters supplied to the
 // create/update ExpressRouteCircuitAuthorization operation
-func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdate(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (result ExpressRouteCircuitAuthorization, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, authorizationName, authorizationParameters)
+func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdate(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, authorizationName, authorizationParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (*http.Request, error) {
+func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"authorizationName": url.QueryEscape(authorizationName),
 		"circuitName":       url.QueryEscape(circuitName),
@@ -86,7 +89,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdatePreparer(res
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,30 +102,34 @@ func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdatePreparer(res
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateResponder(resp *http.Response) (result ExpressRouteCircuitAuthorization, err error) {
+func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the delete authorization operation deletes the specified
-// authorization from the specified ExpressRouteCircuit.
+// authorization from the specified ExpressRouteCircuit. This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. authorizationName is the name of the
 // authorization.
-func (client ExpressRouteCircuitAuthorizationsClient) Delete(resourceGroupName string, circuitName string, authorizationName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, circuitName, authorizationName)
+func (client ExpressRouteCircuitAuthorizationsClient) Delete(resourceGroupName string, circuitName string, authorizationName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, circuitName, authorizationName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -135,14 +142,14 @@ func (client ExpressRouteCircuitAuthorizationsClient) Delete(resourceGroupName s
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client ExpressRouteCircuitAuthorizationsClient) DeletePreparer(resourceGroupName string, circuitName string, authorizationName string) (*http.Request, error) {
+func (client ExpressRouteCircuitAuthorizationsClient) DeletePreparer(resourceGroupName string, circuitName string, authorizationName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"authorizationName": url.QueryEscape(authorizationName),
 		"circuitName":       url.QueryEscape(circuitName),
@@ -154,7 +161,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) DeletePreparer(resourceGro
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -166,7 +173,9 @@ func (client ExpressRouteCircuitAuthorizationsClient) DeletePreparer(resourceGro
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitAuthorizationsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -187,7 +196,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) DeleteResponder(resp *http
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. authorizationName is the name of the
 // authorization.
-func (client ExpressRouteCircuitAuthorizationsClient) Get(resourceGroupName string, circuitName string, authorizationName string) (result ExpressRouteCircuitAuthorization, ae error) {
+func (client ExpressRouteCircuitAuthorizationsClient) Get(resourceGroupName string, circuitName string, authorizationName string) (result ExpressRouteCircuitAuthorization, err error) {
 	req, err := client.GetPreparer(resourceGroupName, circuitName, authorizationName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "Get", nil, "Failure preparing request")
@@ -201,7 +210,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) Get(resourceGroupName stri
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -232,7 +241,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) GetPreparer(resourceGroupN
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitAuthorizationsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -253,7 +262,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) GetResponder(resp *http.Re
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the curcuit.
-func (client ExpressRouteCircuitAuthorizationsClient) List(resourceGroupName string, circuitName string) (result AuthorizationListResult, ae error) {
+func (client ExpressRouteCircuitAuthorizationsClient) List(resourceGroupName string, circuitName string) (result AuthorizationListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName, circuitName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "List", nil, "Failure preparing request")
@@ -267,7 +276,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) List(resourceGroupName str
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -297,7 +306,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) ListPreparer(resourceGroup
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitAuthorizationsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -314,7 +323,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) ListResponder(resp *http.R
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ExpressRouteCircuitAuthorizationsClient) ListNextResults(lastResults AuthorizationListResult) (result AuthorizationListResult, ae error) {
+func (client ExpressRouteCircuitAuthorizationsClient) ListNextResults(lastResults AuthorizationListResult) (result AuthorizationListResult, err error) {
 	req, err := lastResults.AuthorizationListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "List", nil, "Failure preparing next results request request")
@@ -331,7 +340,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) ListNextResults(lastResult
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuitpeerings.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuitpeerings.go
@@ -47,34 +47,36 @@ func NewExpressRouteCircuitPeeringsClientWithBaseURI(baseURI string, subscriptio
 }
 
 // CreateOrUpdate the Put Pering operation creates/updates an peering in the
-// specified ExpressRouteCircuits
+// specified ExpressRouteCircuits This method may poll for completion.
+// Polling can be canceled by passing the cancel channel argument. The
+// channel will be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. peeringName is the name of the peering.
 // peeringParameters is parameters supplied to the create/update
 // ExpressRouteCircuit Peering operation
-func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdate(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (result ExpressRouteCircuitPeering, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, peeringName, peeringParameters)
+func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdate(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, peeringName, peeringParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (*http.Request, error) {
+func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"circuitName":       url.QueryEscape(circuitName),
 		"peeringName":       url.QueryEscape(peeringName),
@@ -86,7 +88,7 @@ func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdatePreparer(resourceG
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,29 +101,32 @@ func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdatePreparer(resourceG
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdateResponder(resp *http.Response) (result ExpressRouteCircuitPeering, err error) {
+func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the delete peering operation deletes the specified peering from the
-// ExpressRouteCircuit.
+// ExpressRouteCircuit. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. peeringName is the name of the peering.
-func (client ExpressRouteCircuitPeeringsClient) Delete(resourceGroupName string, circuitName string, peeringName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, circuitName, peeringName)
+func (client ExpressRouteCircuitPeeringsClient) Delete(resourceGroupName string, circuitName string, peeringName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, circuitName, peeringName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -134,14 +139,14 @@ func (client ExpressRouteCircuitPeeringsClient) Delete(resourceGroupName string,
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client ExpressRouteCircuitPeeringsClient) DeletePreparer(resourceGroupName string, circuitName string, peeringName string) (*http.Request, error) {
+func (client ExpressRouteCircuitPeeringsClient) DeletePreparer(resourceGroupName string, circuitName string, peeringName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"circuitName":       url.QueryEscape(circuitName),
 		"peeringName":       url.QueryEscape(peeringName),
@@ -153,7 +158,7 @@ func (client ExpressRouteCircuitPeeringsClient) DeletePreparer(resourceGroupName
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -165,7 +170,9 @@ func (client ExpressRouteCircuitPeeringsClient) DeletePreparer(resourceGroupName
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitPeeringsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -185,7 +192,7 @@ func (client ExpressRouteCircuitPeeringsClient) DeleteResponder(resp *http.Respo
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. peeringName is the name of the peering.
-func (client ExpressRouteCircuitPeeringsClient) Get(resourceGroupName string, circuitName string, peeringName string) (result ExpressRouteCircuitPeering, ae error) {
+func (client ExpressRouteCircuitPeeringsClient) Get(resourceGroupName string, circuitName string, peeringName string) (result ExpressRouteCircuitPeering, err error) {
 	req, err := client.GetPreparer(resourceGroupName, circuitName, peeringName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "Get", nil, "Failure preparing request")
@@ -199,7 +206,7 @@ func (client ExpressRouteCircuitPeeringsClient) Get(resourceGroupName string, ci
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -230,7 +237,7 @@ func (client ExpressRouteCircuitPeeringsClient) GetPreparer(resourceGroupName st
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitPeeringsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -251,7 +258,7 @@ func (client ExpressRouteCircuitPeeringsClient) GetResponder(resp *http.Response
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the curcuit.
-func (client ExpressRouteCircuitPeeringsClient) List(resourceGroupName string, circuitName string) (result ExpressRouteCircuitPeeringListResult, ae error) {
+func (client ExpressRouteCircuitPeeringsClient) List(resourceGroupName string, circuitName string) (result ExpressRouteCircuitPeeringListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName, circuitName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "List", nil, "Failure preparing request")
@@ -265,7 +272,7 @@ func (client ExpressRouteCircuitPeeringsClient) List(resourceGroupName string, c
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -295,7 +302,7 @@ func (client ExpressRouteCircuitPeeringsClient) ListPreparer(resourceGroupName s
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitPeeringsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -312,7 +319,7 @@ func (client ExpressRouteCircuitPeeringsClient) ListResponder(resp *http.Respons
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ExpressRouteCircuitPeeringsClient) ListNextResults(lastResults ExpressRouteCircuitPeeringListResult) (result ExpressRouteCircuitPeeringListResult, ae error) {
+func (client ExpressRouteCircuitPeeringsClient) ListNextResults(lastResults ExpressRouteCircuitPeeringListResult) (result ExpressRouteCircuitPeeringListResult, err error) {
 	req, err := lastResults.ExpressRouteCircuitPeeringListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "List", nil, "Failure preparing next results request request")
@@ -329,7 +336,7 @@ func (client ExpressRouteCircuitPeeringsClient) ListNextResults(lastResults Expr
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuits.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuits.go
@@ -47,33 +47,35 @@ func NewExpressRouteCircuitsClientWithBaseURI(baseURI string, subscriptionID str
 }
 
 // CreateOrUpdate the Put ExpressRouteCircuit operation creates/updates a
-// ExpressRouteCircuit
+// ExpressRouteCircuit This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the circuit. parameters is parameters supplied to the
 // create/delete ExpressRouteCircuit operation
-func (client ExpressRouteCircuitsClient) CreateOrUpdate(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (result ExpressRouteCircuit, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, parameters)
+func (client ExpressRouteCircuitsClient) CreateOrUpdate(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ExpressRouteCircuitsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (*http.Request, error) {
+func (client ExpressRouteCircuitsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"circuitName":       url.QueryEscape(circuitName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -84,7 +86,7 @@ func (client ExpressRouteCircuitsClient) CreateOrUpdatePreparer(resourceGroupNam
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -97,29 +99,32 @@ func (client ExpressRouteCircuitsClient) CreateOrUpdatePreparer(resourceGroupNam
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client ExpressRouteCircuitsClient) CreateOrUpdateResponder(resp *http.Response) (result ExpressRouteCircuit, err error) {
+func (client ExpressRouteCircuitsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the delete ExpressRouteCircuit operation deletes the specified
-// ExpressRouteCircuit.
+// ExpressRouteCircuit. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route Circuit.
-func (client ExpressRouteCircuitsClient) Delete(resourceGroupName string, circuitName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, circuitName)
+func (client ExpressRouteCircuitsClient) Delete(resourceGroupName string, circuitName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, circuitName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -132,14 +137,14 @@ func (client ExpressRouteCircuitsClient) Delete(resourceGroupName string, circui
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client ExpressRouteCircuitsClient) DeletePreparer(resourceGroupName string, circuitName string) (*http.Request, error) {
+func (client ExpressRouteCircuitsClient) DeletePreparer(resourceGroupName string, circuitName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"circuitName":       url.QueryEscape(circuitName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -150,7 +155,7 @@ func (client ExpressRouteCircuitsClient) DeletePreparer(resourceGroupName string
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -162,7 +167,9 @@ func (client ExpressRouteCircuitsClient) DeletePreparer(resourceGroupName string
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -182,7 +189,7 @@ func (client ExpressRouteCircuitsClient) DeleteResponder(resp *http.Response) (r
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the circuit.
-func (client ExpressRouteCircuitsClient) Get(resourceGroupName string, circuitName string) (result ExpressRouteCircuit, ae error) {
+func (client ExpressRouteCircuitsClient) Get(resourceGroupName string, circuitName string) (result ExpressRouteCircuit, err error) {
 	req, err := client.GetPreparer(resourceGroupName, circuitName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "Get", nil, "Failure preparing request")
@@ -196,7 +203,7 @@ func (client ExpressRouteCircuitsClient) Get(resourceGroupName string, circuitNa
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -226,7 +233,7 @@ func (client ExpressRouteCircuitsClient) GetPreparer(resourceGroupName string, c
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -246,7 +253,7 @@ func (client ExpressRouteCircuitsClient) GetResponder(resp *http.Response) (resu
 // ExpressRouteCircuits in a resource group.
 //
 // resourceGroupName is the name of the resource group.
-func (client ExpressRouteCircuitsClient) List(resourceGroupName string) (result ExpressRouteCircuitListResult, ae error) {
+func (client ExpressRouteCircuitsClient) List(resourceGroupName string) (result ExpressRouteCircuitListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "List", nil, "Failure preparing request")
@@ -260,7 +267,7 @@ func (client ExpressRouteCircuitsClient) List(resourceGroupName string) (result 
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -289,7 +296,7 @@ func (client ExpressRouteCircuitsClient) ListPreparer(resourceGroupName string) 
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -306,7 +313,7 @@ func (client ExpressRouteCircuitsClient) ListResponder(resp *http.Response) (res
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ExpressRouteCircuitsClient) ListNextResults(lastResults ExpressRouteCircuitListResult) (result ExpressRouteCircuitListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListNextResults(lastResults ExpressRouteCircuitListResult) (result ExpressRouteCircuitListResult, err error) {
 	req, err := lastResults.ExpressRouteCircuitListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "List", nil, "Failure preparing next results request request")
@@ -323,7 +330,7 @@ func (client ExpressRouteCircuitsClient) ListNextResults(lastResults ExpressRout
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -331,7 +338,7 @@ func (client ExpressRouteCircuitsClient) ListNextResults(lastResults ExpressRout
 
 // ListAll the List ExpressRouteCircuit opertion retrieves all the
 // ExpressRouteCircuits in a subscription.
-func (client ExpressRouteCircuitsClient) ListAll() (result ExpressRouteCircuitListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListAll() (result ExpressRouteCircuitListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListAll", nil, "Failure preparing request")
@@ -345,7 +352,7 @@ func (client ExpressRouteCircuitsClient) ListAll() (result ExpressRouteCircuitLi
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -373,7 +380,7 @@ func (client ExpressRouteCircuitsClient) ListAllPreparer() (*http.Request, error
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitsClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -390,7 +397,7 @@ func (client ExpressRouteCircuitsClient) ListAllResponder(resp *http.Response) (
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client ExpressRouteCircuitsClient) ListAllNextResults(lastResults ExpressRouteCircuitListResult) (result ExpressRouteCircuitListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListAllNextResults(lastResults ExpressRouteCircuitListResult) (result ExpressRouteCircuitListResult, err error) {
 	req, err := lastResults.ExpressRouteCircuitListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListAll", nil, "Failure preparing next results request request")
@@ -407,7 +414,7 @@ func (client ExpressRouteCircuitsClient) ListAllNextResults(lastResults ExpressR
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -419,7 +426,7 @@ func (client ExpressRouteCircuitsClient) ListAllNextResults(lastResults ExpressR
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the circuit.
-func (client ExpressRouteCircuitsClient) ListArpTable(resourceGroupName string, circuitName string) (result ExpressRouteCircuitsArpTableListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListArpTable(resourceGroupName string, circuitName string) (result ExpressRouteCircuitsArpTableListResult, err error) {
 	req, err := client.ListArpTablePreparer(resourceGroupName, circuitName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListArpTable", nil, "Failure preparing request")
@@ -433,7 +440,7 @@ func (client ExpressRouteCircuitsClient) ListArpTable(resourceGroupName string, 
 
 	result, err = client.ListArpTableResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListArpTable", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListArpTable", resp, "Failure responding to request")
 	}
 
 	return
@@ -463,7 +470,7 @@ func (client ExpressRouteCircuitsClient) ListArpTablePreparer(resourceGroupName 
 // ListArpTableSender sends the ListArpTable request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitsClient) ListArpTableSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListArpTableResponder handles the response to the ListArpTable request. The method always
@@ -480,7 +487,7 @@ func (client ExpressRouteCircuitsClient) ListArpTableResponder(resp *http.Respon
 }
 
 // ListArpTableNextResults retrieves the next set of results, if any.
-func (client ExpressRouteCircuitsClient) ListArpTableNextResults(lastResults ExpressRouteCircuitsArpTableListResult) (result ExpressRouteCircuitsArpTableListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListArpTableNextResults(lastResults ExpressRouteCircuitsArpTableListResult) (result ExpressRouteCircuitsArpTableListResult, err error) {
 	req, err := lastResults.ExpressRouteCircuitsArpTableListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListArpTable", nil, "Failure preparing next results request request")
@@ -497,7 +504,7 @@ func (client ExpressRouteCircuitsClient) ListArpTableNextResults(lastResults Exp
 
 	result, err = client.ListArpTableResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListArpTable", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListArpTable", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -509,7 +516,7 @@ func (client ExpressRouteCircuitsClient) ListArpTableNextResults(lastResults Exp
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the circuit.
-func (client ExpressRouteCircuitsClient) ListRoutesTable(resourceGroupName string, circuitName string) (result ExpressRouteCircuitsRoutesTableListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListRoutesTable(resourceGroupName string, circuitName string) (result ExpressRouteCircuitsRoutesTableListResult, err error) {
 	req, err := client.ListRoutesTablePreparer(resourceGroupName, circuitName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListRoutesTable", nil, "Failure preparing request")
@@ -523,7 +530,7 @@ func (client ExpressRouteCircuitsClient) ListRoutesTable(resourceGroupName strin
 
 	result, err = client.ListRoutesTableResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListRoutesTable", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListRoutesTable", resp, "Failure responding to request")
 	}
 
 	return
@@ -553,7 +560,7 @@ func (client ExpressRouteCircuitsClient) ListRoutesTablePreparer(resourceGroupNa
 // ListRoutesTableSender sends the ListRoutesTable request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitsClient) ListRoutesTableSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListRoutesTableResponder handles the response to the ListRoutesTable request. The method always
@@ -570,7 +577,7 @@ func (client ExpressRouteCircuitsClient) ListRoutesTableResponder(resp *http.Res
 }
 
 // ListRoutesTableNextResults retrieves the next set of results, if any.
-func (client ExpressRouteCircuitsClient) ListRoutesTableNextResults(lastResults ExpressRouteCircuitsRoutesTableListResult) (result ExpressRouteCircuitsRoutesTableListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListRoutesTableNextResults(lastResults ExpressRouteCircuitsRoutesTableListResult) (result ExpressRouteCircuitsRoutesTableListResult, err error) {
 	req, err := lastResults.ExpressRouteCircuitsRoutesTableListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListRoutesTable", nil, "Failure preparing next results request request")
@@ -587,7 +594,7 @@ func (client ExpressRouteCircuitsClient) ListRoutesTableNextResults(lastResults 
 
 	result, err = client.ListRoutesTableResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListRoutesTable", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListRoutesTable", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -598,7 +605,7 @@ func (client ExpressRouteCircuitsClient) ListRoutesTableNextResults(lastResults 
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the loadBalancer.
-func (client ExpressRouteCircuitsClient) ListStats(resourceGroupName string, circuitName string) (result ExpressRouteCircuitsStatsListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListStats(resourceGroupName string, circuitName string) (result ExpressRouteCircuitsStatsListResult, err error) {
 	req, err := client.ListStatsPreparer(resourceGroupName, circuitName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListStats", nil, "Failure preparing request")
@@ -612,7 +619,7 @@ func (client ExpressRouteCircuitsClient) ListStats(resourceGroupName string, cir
 
 	result, err = client.ListStatsResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListStats", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListStats", resp, "Failure responding to request")
 	}
 
 	return
@@ -642,7 +649,7 @@ func (client ExpressRouteCircuitsClient) ListStatsPreparer(resourceGroupName str
 // ListStatsSender sends the ListStats request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteCircuitsClient) ListStatsSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListStatsResponder handles the response to the ListStats request. The method always
@@ -659,7 +666,7 @@ func (client ExpressRouteCircuitsClient) ListStatsResponder(resp *http.Response)
 }
 
 // ListStatsNextResults retrieves the next set of results, if any.
-func (client ExpressRouteCircuitsClient) ListStatsNextResults(lastResults ExpressRouteCircuitsStatsListResult) (result ExpressRouteCircuitsStatsListResult, ae error) {
+func (client ExpressRouteCircuitsClient) ListStatsNextResults(lastResults ExpressRouteCircuitsStatsListResult) (result ExpressRouteCircuitsStatsListResult, err error) {
 	req, err := lastResults.ExpressRouteCircuitsStatsListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListStats", nil, "Failure preparing next results request request")
@@ -676,7 +683,7 @@ func (client ExpressRouteCircuitsClient) ListStatsNextResults(lastResults Expres
 
 	result, err = client.ListStatsResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListStats", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "ListStats", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressrouteserviceproviders.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressrouteserviceproviders.go
@@ -48,7 +48,7 @@ func NewExpressRouteServiceProvidersClientWithBaseURI(baseURI string, subscripti
 
 // List the List ExpressRouteServiceProvider opertion retrieves all the
 // available ExpressRouteServiceProviders.
-func (client ExpressRouteServiceProvidersClient) List() (result ExpressRouteServiceProviderListResult, ae error) {
+func (client ExpressRouteServiceProvidersClient) List() (result ExpressRouteServiceProviderListResult, err error) {
 	req, err := client.ListPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteServiceProvidersClient", "List", nil, "Failure preparing request")
@@ -62,7 +62,7 @@ func (client ExpressRouteServiceProvidersClient) List() (result ExpressRouteServ
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteServiceProvidersClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteServiceProvidersClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -90,7 +90,7 @@ func (client ExpressRouteServiceProvidersClient) ListPreparer() (*http.Request, 
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ExpressRouteServiceProvidersClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -107,7 +107,7 @@ func (client ExpressRouteServiceProvidersClient) ListResponder(resp *http.Respon
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ExpressRouteServiceProvidersClient) ListNextResults(lastResults ExpressRouteServiceProviderListResult) (result ExpressRouteServiceProviderListResult, ae error) {
+func (client ExpressRouteServiceProvidersClient) ListNextResults(lastResults ExpressRouteServiceProviderListResult) (result ExpressRouteServiceProviderListResult, err error) {
 	req, err := lastResults.ExpressRouteServiceProviderListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteServiceProvidersClient", "List", nil, "Failure preparing next results request request")
@@ -124,7 +124,7 @@ func (client ExpressRouteServiceProvidersClient) ListNextResults(lastResults Exp
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/ExpressRouteServiceProvidersClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/ExpressRouteServiceProvidersClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/interfaces.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/interfaces.go
@@ -46,33 +46,35 @@ func NewInterfacesClientWithBaseURI(baseURI string, subscriptionID string) Inter
 }
 
 // CreateOrUpdate the Put NetworkInterface operation creates/updates a
-// networkInterface
+// networkInterface This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. networkInterfaceName
 // is the name of the network interface. parameters is parameters supplied to
 // the create/update NetworkInterface operation
-func (client InterfacesClient) CreateOrUpdate(resourceGroupName string, networkInterfaceName string, parameters Interface) (result Interface, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkInterfaceName, parameters)
+func (client InterfacesClient) CreateOrUpdate(resourceGroupName string, networkInterfaceName string, parameters Interface, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkInterfaceName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client InterfacesClient) CreateOrUpdatePreparer(resourceGroupName string, networkInterfaceName string, parameters Interface) (*http.Request, error) {
+func (client InterfacesClient) CreateOrUpdatePreparer(resourceGroupName string, networkInterfaceName string, parameters Interface, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkInterfaceName": url.QueryEscape(networkInterfaceName),
 		"resourceGroupName":    url.QueryEscape(resourceGroupName),
@@ -83,7 +85,7 @@ func (client InterfacesClient) CreateOrUpdatePreparer(resourceGroupName string, 
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -96,29 +98,32 @@ func (client InterfacesClient) CreateOrUpdatePreparer(resourceGroupName string, 
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client InterfacesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client InterfacesClient) CreateOrUpdateResponder(resp *http.Response) (result Interface, err error) {
+func (client InterfacesClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the delete netwokInterface operation deletes the specified
-// netwokInterface.
+// netwokInterface. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. networkInterfaceName
 // is the name of the network interface.
-func (client InterfacesClient) Delete(resourceGroupName string, networkInterfaceName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, networkInterfaceName)
+func (client InterfacesClient) Delete(resourceGroupName string, networkInterfaceName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, networkInterfaceName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -131,14 +136,14 @@ func (client InterfacesClient) Delete(resourceGroupName string, networkInterface
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client InterfacesClient) DeletePreparer(resourceGroupName string, networkInterfaceName string) (*http.Request, error) {
+func (client InterfacesClient) DeletePreparer(resourceGroupName string, networkInterfaceName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkInterfaceName": url.QueryEscape(networkInterfaceName),
 		"resourceGroupName":    url.QueryEscape(resourceGroupName),
@@ -149,7 +154,7 @@ func (client InterfacesClient) DeletePreparer(resourceGroupName string, networkI
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -161,7 +166,9 @@ func (client InterfacesClient) DeletePreparer(resourceGroupName string, networkI
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client InterfacesClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -182,7 +189,7 @@ func (client InterfacesClient) DeleteResponder(resp *http.Response) (result auto
 // resourceGroupName is the name of the resource group. networkInterfaceName
 // is the name of the network interface. expand is expand references
 // resources.
-func (client InterfacesClient) Get(resourceGroupName string, networkInterfaceName string, expand string) (result Interface, ae error) {
+func (client InterfacesClient) Get(resourceGroupName string, networkInterfaceName string, expand string) (result Interface, err error) {
 	req, err := client.GetPreparer(resourceGroupName, networkInterfaceName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "Get", nil, "Failure preparing request")
@@ -196,7 +203,7 @@ func (client InterfacesClient) Get(resourceGroupName string, networkInterfaceNam
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -229,7 +236,7 @@ func (client InterfacesClient) GetPreparer(resourceGroupName string, networkInte
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client InterfacesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -253,7 +260,7 @@ func (client InterfacesClient) GetResponder(resp *http.Response) (result Interfa
 // virtualMachineScaleSetName is the name of the virtual machine scale set.
 // virtualmachineIndex is the virtual machine index. networkInterfaceName is
 // the name of the network interface. expand is expand references resources.
-func (client InterfacesClient) GetVirtualMachineScaleSetNetworkInterface(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, expand string) (result Interface, ae error) {
+func (client InterfacesClient) GetVirtualMachineScaleSetNetworkInterface(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, expand string) (result Interface, err error) {
 	req, err := client.GetVirtualMachineScaleSetNetworkInterfacePreparer(resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "GetVirtualMachineScaleSetNetworkInterface", nil, "Failure preparing request")
@@ -267,7 +274,7 @@ func (client InterfacesClient) GetVirtualMachineScaleSetNetworkInterface(resourc
 
 	result, err = client.GetVirtualMachineScaleSetNetworkInterfaceResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "GetVirtualMachineScaleSetNetworkInterface", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "GetVirtualMachineScaleSetNetworkInterface", resp, "Failure responding to request")
 	}
 
 	return
@@ -302,7 +309,7 @@ func (client InterfacesClient) GetVirtualMachineScaleSetNetworkInterfacePreparer
 // GetVirtualMachineScaleSetNetworkInterfaceSender sends the GetVirtualMachineScaleSetNetworkInterface request. The method will close the
 // http.Response Body if it receives an error.
 func (client InterfacesClient) GetVirtualMachineScaleSetNetworkInterfaceSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetVirtualMachineScaleSetNetworkInterfaceResponder handles the response to the GetVirtualMachineScaleSetNetworkInterface request. The method always
@@ -322,7 +329,7 @@ func (client InterfacesClient) GetVirtualMachineScaleSetNetworkInterfaceResponde
 // networkInterfaces in a resource group.
 //
 // resourceGroupName is the name of the resource group.
-func (client InterfacesClient) List(resourceGroupName string) (result InterfaceListResult, ae error) {
+func (client InterfacesClient) List(resourceGroupName string) (result InterfaceListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "List", nil, "Failure preparing request")
@@ -336,7 +343,7 @@ func (client InterfacesClient) List(resourceGroupName string) (result InterfaceL
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -365,7 +372,7 @@ func (client InterfacesClient) ListPreparer(resourceGroupName string) (*http.Req
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client InterfacesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -382,7 +389,7 @@ func (client InterfacesClient) ListResponder(resp *http.Response) (result Interf
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client InterfacesClient) ListNextResults(lastResults InterfaceListResult) (result InterfaceListResult, ae error) {
+func (client InterfacesClient) ListNextResults(lastResults InterfaceListResult) (result InterfaceListResult, err error) {
 	req, err := lastResults.InterfaceListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "List", nil, "Failure preparing next results request request")
@@ -399,7 +406,7 @@ func (client InterfacesClient) ListNextResults(lastResults InterfaceListResult) 
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -407,7 +414,7 @@ func (client InterfacesClient) ListNextResults(lastResults InterfaceListResult) 
 
 // ListAll the List networkInterfaces opertion retrieves all the
 // networkInterfaces in a subscription.
-func (client InterfacesClient) ListAll() (result InterfaceListResult, ae error) {
+func (client InterfacesClient) ListAll() (result InterfaceListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "ListAll", nil, "Failure preparing request")
@@ -421,7 +428,7 @@ func (client InterfacesClient) ListAll() (result InterfaceListResult, ae error) 
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -449,7 +456,7 @@ func (client InterfacesClient) ListAllPreparer() (*http.Request, error) {
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client InterfacesClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -466,7 +473,7 @@ func (client InterfacesClient) ListAllResponder(resp *http.Response) (result Int
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client InterfacesClient) ListAllNextResults(lastResults InterfaceListResult) (result InterfaceListResult, ae error) {
+func (client InterfacesClient) ListAllNextResults(lastResults InterfaceListResult) (result InterfaceListResult, err error) {
 	req, err := lastResults.InterfaceListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "ListAll", nil, "Failure preparing next results request request")
@@ -483,7 +490,7 @@ func (client InterfacesClient) ListAllNextResults(lastResults InterfaceListResul
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -495,7 +502,7 @@ func (client InterfacesClient) ListAllNextResults(lastResults InterfaceListResul
 //
 // resourceGroupName is the name of the resource group.
 // virtualMachineScaleSetName is the name of the virtual machine scale set.
-func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string) (result InterfaceListResult, ae error) {
+func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string) (result InterfaceListResult, err error) {
 	req, err := client.ListVirtualMachineScaleSetNetworkInterfacesPreparer(resourceGroupName, virtualMachineScaleSetName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetNetworkInterfaces", nil, "Failure preparing request")
@@ -509,7 +516,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfaces(resou
 
 	result, err = client.ListVirtualMachineScaleSetNetworkInterfacesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetNetworkInterfaces", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetNetworkInterfaces", resp, "Failure responding to request")
 	}
 
 	return
@@ -539,7 +546,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesPrepar
 // ListVirtualMachineScaleSetNetworkInterfacesSender sends the ListVirtualMachineScaleSetNetworkInterfaces request. The method will close the
 // http.Response Body if it receives an error.
 func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListVirtualMachineScaleSetNetworkInterfacesResponder handles the response to the ListVirtualMachineScaleSetNetworkInterfaces request. The method always
@@ -556,7 +563,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesRespon
 }
 
 // ListVirtualMachineScaleSetNetworkInterfacesNextResults retrieves the next set of results, if any.
-func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesNextResults(lastResults InterfaceListResult) (result InterfaceListResult, ae error) {
+func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesNextResults(lastResults InterfaceListResult) (result InterfaceListResult, err error) {
 	req, err := lastResults.InterfaceListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetNetworkInterfaces", nil, "Failure preparing next results request request")
@@ -573,7 +580,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesNextRe
 
 	result, err = client.ListVirtualMachineScaleSetNetworkInterfacesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetNetworkInterfaces", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetNetworkInterfaces", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -586,7 +593,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesNextRe
 // resourceGroupName is the name of the resource group.
 // virtualMachineScaleSetName is the name of the virtual machine scale set.
 // virtualmachineIndex is the virtual machine index.
-func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string) (result InterfaceListResult, ae error) {
+func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string) (result InterfaceListResult, err error) {
 	req, err := client.ListVirtualMachineScaleSetVMNetworkInterfacesPreparer(resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetVMNetworkInterfaces", nil, "Failure preparing request")
@@ -600,7 +607,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfaces(res
 
 	result, err = client.ListVirtualMachineScaleSetVMNetworkInterfacesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetVMNetworkInterfaces", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetVMNetworkInterfaces", resp, "Failure responding to request")
 	}
 
 	return
@@ -631,7 +638,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesPrep
 // ListVirtualMachineScaleSetVMNetworkInterfacesSender sends the ListVirtualMachineScaleSetVMNetworkInterfaces request. The method will close the
 // http.Response Body if it receives an error.
 func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListVirtualMachineScaleSetVMNetworkInterfacesResponder handles the response to the ListVirtualMachineScaleSetVMNetworkInterfaces request. The method always
@@ -648,7 +655,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesResp
 }
 
 // ListVirtualMachineScaleSetVMNetworkInterfacesNextResults retrieves the next set of results, if any.
-func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesNextResults(lastResults InterfaceListResult) (result InterfaceListResult, ae error) {
+func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesNextResults(lastResults InterfaceListResult) (result InterfaceListResult, err error) {
 	req, err := lastResults.InterfaceListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetVMNetworkInterfaces", nil, "Failure preparing next results request request")
@@ -665,7 +672,7 @@ func (client InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesNext
 
 	result, err = client.ListVirtualMachineScaleSetVMNetworkInterfacesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetVMNetworkInterfaces", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/InterfacesClient", "ListVirtualMachineScaleSetVMNetworkInterfaces", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/loadbalancers.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/loadbalancers.go
@@ -46,33 +46,36 @@ func NewLoadBalancersClientWithBaseURI(baseURI string, subscriptionID string) Lo
 	return LoadBalancersClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// CreateOrUpdate the Put LoadBalancer operation creates/updates a LoadBalancer
+// CreateOrUpdate the Put LoadBalancer operation creates/updates a
+// LoadBalancer This method may poll for completion. Polling can be canceled
+// by passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. loadBalancerName is
 // the name of the loadBalancer. parameters is parameters supplied to the
 // create/delete LoadBalancer operation
-func (client LoadBalancersClient) CreateOrUpdate(resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (result LoadBalancer, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, loadBalancerName, parameters)
+func (client LoadBalancersClient) CreateOrUpdate(resourceGroupName string, loadBalancerName string, parameters LoadBalancer, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, loadBalancerName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client LoadBalancersClient) CreateOrUpdatePreparer(resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (*http.Request, error) {
+func (client LoadBalancersClient) CreateOrUpdatePreparer(resourceGroupName string, loadBalancerName string, parameters LoadBalancer, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"loadBalancerName":  url.QueryEscape(loadBalancerName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -83,7 +86,7 @@ func (client LoadBalancersClient) CreateOrUpdatePreparer(resourceGroupName strin
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -96,28 +99,32 @@ func (client LoadBalancersClient) CreateOrUpdatePreparer(resourceGroupName strin
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client LoadBalancersClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client LoadBalancersClient) CreateOrUpdateResponder(resp *http.Response) (result LoadBalancer, err error) {
+func (client LoadBalancersClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
-// Delete the delete loadbalancer operation deletes the specified loadbalancer.
+// Delete the delete loadbalancer operation deletes the specified
+// loadbalancer. This method may poll for completion. Polling can be canceled
+// by passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. loadBalancerName is
 // the name of the loadBalancer.
-func (client LoadBalancersClient) Delete(resourceGroupName string, loadBalancerName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, loadBalancerName)
+func (client LoadBalancersClient) Delete(resourceGroupName string, loadBalancerName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, loadBalancerName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Delete", nil, "Failure preparing request")
 	}
@@ -130,14 +137,14 @@ func (client LoadBalancersClient) Delete(resourceGroupName string, loadBalancerN
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client LoadBalancersClient) DeletePreparer(resourceGroupName string, loadBalancerName string) (*http.Request, error) {
+func (client LoadBalancersClient) DeletePreparer(resourceGroupName string, loadBalancerName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"loadBalancerName":  url.QueryEscape(loadBalancerName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -148,7 +155,7 @@ func (client LoadBalancersClient) DeletePreparer(resourceGroupName string, loadB
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -160,7 +167,9 @@ func (client LoadBalancersClient) DeletePreparer(resourceGroupName string, loadB
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client LoadBalancersClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -180,7 +189,7 @@ func (client LoadBalancersClient) DeleteResponder(resp *http.Response) (result a
 //
 // resourceGroupName is the name of the resource group. loadBalancerName is
 // the name of the loadBalancer. expand is expand references resources.
-func (client LoadBalancersClient) Get(resourceGroupName string, loadBalancerName string, expand string) (result LoadBalancer, ae error) {
+func (client LoadBalancersClient) Get(resourceGroupName string, loadBalancerName string, expand string) (result LoadBalancer, err error) {
 	req, err := client.GetPreparer(resourceGroupName, loadBalancerName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Get", nil, "Failure preparing request")
@@ -194,7 +203,7 @@ func (client LoadBalancersClient) Get(resourceGroupName string, loadBalancerName
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -227,7 +236,7 @@ func (client LoadBalancersClient) GetPreparer(resourceGroupName string, loadBala
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client LoadBalancersClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -247,7 +256,7 @@ func (client LoadBalancersClient) GetResponder(resp *http.Response) (result Load
 // resource group.
 //
 // resourceGroupName is the name of the resource group.
-func (client LoadBalancersClient) List(resourceGroupName string) (result LoadBalancerListResult, ae error) {
+func (client LoadBalancersClient) List(resourceGroupName string) (result LoadBalancerListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "List", nil, "Failure preparing request")
@@ -261,7 +270,7 @@ func (client LoadBalancersClient) List(resourceGroupName string) (result LoadBal
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -290,7 +299,7 @@ func (client LoadBalancersClient) ListPreparer(resourceGroupName string) (*http.
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client LoadBalancersClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -307,7 +316,7 @@ func (client LoadBalancersClient) ListResponder(resp *http.Response) (result Loa
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client LoadBalancersClient) ListNextResults(lastResults LoadBalancerListResult) (result LoadBalancerListResult, ae error) {
+func (client LoadBalancersClient) ListNextResults(lastResults LoadBalancerListResult) (result LoadBalancerListResult, err error) {
 	req, err := lastResults.LoadBalancerListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "List", nil, "Failure preparing next results request request")
@@ -324,7 +333,7 @@ func (client LoadBalancersClient) ListNextResults(lastResults LoadBalancerListRe
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -332,7 +341,7 @@ func (client LoadBalancersClient) ListNextResults(lastResults LoadBalancerListRe
 
 // ListAll the List loadBalancer opertion retrieves all the loadbalancers in a
 // subscription.
-func (client LoadBalancersClient) ListAll() (result LoadBalancerListResult, ae error) {
+func (client LoadBalancersClient) ListAll() (result LoadBalancerListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "ListAll", nil, "Failure preparing request")
@@ -346,7 +355,7 @@ func (client LoadBalancersClient) ListAll() (result LoadBalancerListResult, ae e
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -374,7 +383,7 @@ func (client LoadBalancersClient) ListAllPreparer() (*http.Request, error) {
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client LoadBalancersClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -391,7 +400,7 @@ func (client LoadBalancersClient) ListAllResponder(resp *http.Response) (result 
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client LoadBalancersClient) ListAllNextResults(lastResults LoadBalancerListResult) (result LoadBalancerListResult, ae error) {
+func (client LoadBalancersClient) ListAllNextResults(lastResults LoadBalancerListResult) (result LoadBalancerListResult, err error) {
 	req, err := lastResults.LoadBalancerListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "ListAll", nil, "Failure preparing next results request request")
@@ -408,7 +417,7 @@ func (client LoadBalancersClient) ListAllNextResults(lastResults LoadBalancerLis
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/LoadBalancersClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/localnetworkgateways.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/localnetworkgateways.go
@@ -48,34 +48,36 @@ func NewLocalNetworkGatewaysClientWithBaseURI(baseURI string, subscriptionID str
 
 // CreateOrUpdate the Put LocalNetworkGateway operation creates/updates a
 // local network gateway in the specified resource group through Network
-// resource provider.
+// resource provider. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // localNetworkGatewayName is the name of the local network gateway.
 // parameters is parameters supplied to the Begin Create or update Local
 // Network Gateway operation through Network resource provider.
-func (client LocalNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (result LocalNetworkGateway, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, localNetworkGatewayName, parameters)
+func (client LocalNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, localNetworkGatewayName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client LocalNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (*http.Request, error) {
+func (client LocalNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"localNetworkGatewayName": url.QueryEscape(localNetworkGatewayName),
 		"resourceGroupName":       url.QueryEscape(resourceGroupName),
@@ -86,7 +88,7 @@ func (client LocalNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupNam
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,29 +101,33 @@ func (client LocalNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupNam
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client LocalNetworkGatewaysClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client LocalNetworkGatewaysClient) CreateOrUpdateResponder(resp *http.Response) (result LocalNetworkGateway, err error) {
+func (client LocalNetworkGatewaysClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the Delete LocalNetworkGateway operation deletes the specifed local
-// network Gateway through Network resource provider.
+// network Gateway through Network resource provider. This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // localNetworkGatewayName is the name of the local network gateway.
-func (client LocalNetworkGatewaysClient) Delete(resourceGroupName string, localNetworkGatewayName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, localNetworkGatewayName)
+func (client LocalNetworkGatewaysClient) Delete(resourceGroupName string, localNetworkGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, localNetworkGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Delete", nil, "Failure preparing request")
 	}
@@ -134,14 +140,14 @@ func (client LocalNetworkGatewaysClient) Delete(resourceGroupName string, localN
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client LocalNetworkGatewaysClient) DeletePreparer(resourceGroupName string, localNetworkGatewayName string) (*http.Request, error) {
+func (client LocalNetworkGatewaysClient) DeletePreparer(resourceGroupName string, localNetworkGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"localNetworkGatewayName": url.QueryEscape(localNetworkGatewayName),
 		"resourceGroupName":       url.QueryEscape(resourceGroupName),
@@ -152,7 +158,7 @@ func (client LocalNetworkGatewaysClient) DeletePreparer(resourceGroupName string
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -164,7 +170,9 @@ func (client LocalNetworkGatewaysClient) DeletePreparer(resourceGroupName string
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client LocalNetworkGatewaysClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -184,7 +192,7 @@ func (client LocalNetworkGatewaysClient) DeleteResponder(resp *http.Response) (r
 //
 // resourceGroupName is the name of the resource group.
 // localNetworkGatewayName is the name of the local network gateway.
-func (client LocalNetworkGatewaysClient) Get(resourceGroupName string, localNetworkGatewayName string) (result LocalNetworkGateway, ae error) {
+func (client LocalNetworkGatewaysClient) Get(resourceGroupName string, localNetworkGatewayName string) (result LocalNetworkGateway, err error) {
 	req, err := client.GetPreparer(resourceGroupName, localNetworkGatewayName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Get", nil, "Failure preparing request")
@@ -198,7 +206,7 @@ func (client LocalNetworkGatewaysClient) Get(resourceGroupName string, localNetw
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -228,7 +236,7 @@ func (client LocalNetworkGatewaysClient) GetPreparer(resourceGroupName string, l
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client LocalNetworkGatewaysClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -248,7 +256,7 @@ func (client LocalNetworkGatewaysClient) GetResponder(resp *http.Response) (resu
 // gateways stored.
 //
 // resourceGroupName is the name of the resource group.
-func (client LocalNetworkGatewaysClient) List(resourceGroupName string) (result LocalNetworkGatewayListResult, ae error) {
+func (client LocalNetworkGatewaysClient) List(resourceGroupName string) (result LocalNetworkGatewayListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "List", nil, "Failure preparing request")
@@ -262,7 +270,7 @@ func (client LocalNetworkGatewaysClient) List(resourceGroupName string) (result 
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -291,7 +299,7 @@ func (client LocalNetworkGatewaysClient) ListPreparer(resourceGroupName string) 
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client LocalNetworkGatewaysClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -308,7 +316,7 @@ func (client LocalNetworkGatewaysClient) ListResponder(resp *http.Response) (res
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client LocalNetworkGatewaysClient) ListNextResults(lastResults LocalNetworkGatewayListResult) (result LocalNetworkGatewayListResult, ae error) {
+func (client LocalNetworkGatewaysClient) ListNextResults(lastResults LocalNetworkGatewayListResult) (result LocalNetworkGatewayListResult, err error) {
 	req, err := lastResults.LocalNetworkGatewayListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "List", nil, "Failure preparing next results request request")
@@ -325,7 +333,7 @@ func (client LocalNetworkGatewaysClient) ListNextResults(lastResults LocalNetwor
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/models.go
@@ -487,10 +487,10 @@ type ApplicationGatewayBackendHTTPSettings struct {
 // ApplicationGatewayBackendHTTPSettingsPropertiesFormat is properties of
 // Backend address pool settings of application gateway
 type ApplicationGatewayBackendHTTPSettingsPropertiesFormat struct {
-	Port                *int                                  `json:"port,omitempty"`
+	Port                *int32                                `json:"port,omitempty"`
 	Protocol            ApplicationGatewayProtocol            `json:"protocol,omitempty"`
 	CookieBasedAffinity ApplicationGatewayCookieBasedAffinity `json:"cookieBasedAffinity,omitempty"`
-	RequestTimeout      *int                                  `json:"requestTimeout,omitempty"`
+	RequestTimeout      *int32                                `json:"requestTimeout,omitempty"`
 	Probe               *SubResource                          `json:"probe,omitempty"`
 	ProvisioningState   *string                               `json:"provisioningState,omitempty"`
 }
@@ -525,7 +525,7 @@ type ApplicationGatewayFrontendPort struct {
 // ApplicationGatewayFrontendPortPropertiesFormat is properties of Frontend
 // Port of application gateway
 type ApplicationGatewayFrontendPortPropertiesFormat struct {
-	Port              *int    `json:"port,omitempty"`
+	Port              *int32  `json:"port,omitempty"`
 	ProvisioningState *string `json:"provisioningState,omitempty"`
 }
 
@@ -616,9 +616,9 @@ type ApplicationGatewayProbePropertiesFormat struct {
 	Protocol           ApplicationGatewayProtocol `json:"protocol,omitempty"`
 	Host               *string                    `json:"host,omitempty"`
 	Path               *string                    `json:"path,omitempty"`
-	Interval           *int                       `json:"interval,omitempty"`
-	Timeout            *int                       `json:"timeout,omitempty"`
-	UnhealthyThreshold *int                       `json:"unhealthyThreshold,omitempty"`
+	Interval           *int32                     `json:"interval,omitempty"`
+	Timeout            *int32                     `json:"timeout,omitempty"`
+	UnhealthyThreshold *int32                     `json:"unhealthyThreshold,omitempty"`
 	ProvisioningState  *string                    `json:"provisioningState,omitempty"`
 }
 
@@ -664,7 +664,7 @@ type ApplicationGatewayRequestRoutingRulePropertiesFormat struct {
 type ApplicationGatewaySku struct {
 	Name     ApplicationGatewaySkuName `json:"name,omitempty"`
 	Tier     ApplicationGatewayTier    `json:"tier,omitempty"`
-	Capacity *int                      `json:"capacity,omitempty"`
+	Capacity *int32                    `json:"capacity,omitempty"`
 }
 
 // ApplicationGatewaySslCertificate is sSL certificates of application gateway
@@ -760,7 +760,7 @@ type BackendAddressPoolPropertiesFormat struct {
 // ConnectionResetSharedKey is
 type ConnectionResetSharedKey struct {
 	autorest.Response `json:"-"`
-	KeyLength         *int32 `json:"keyLength,omitempty"`
+	KeyLength         *int64 `json:"keyLength,omitempty"`
 }
 
 // ConnectionSharedKey is response for GetConnectionSharedKey Api servive call
@@ -869,7 +869,7 @@ type ExpressRouteCircuitPeering struct {
 type ExpressRouteCircuitPeeringConfig struct {
 	AdvertisedPublicPrefixes      *[]string                                             `json:"advertisedPublicPrefixes,omitempty"`
 	AdvertisedPublicPrefixesState ExpressRouteCircuitPeeringAdvertisedPublicPrefixState `json:"advertisedPublicPrefixesState,omitempty"`
-	CustomerASN                   *int                                                  `json:"customerASN,omitempty"`
+	CustomerASN                   *int32                                                `json:"customerASN,omitempty"`
 	RoutingRegistryName           *string                                               `json:"routingRegistryName,omitempty"`
 }
 
@@ -897,14 +897,14 @@ func (client ExpressRouteCircuitPeeringListResult) ExpressRouteCircuitPeeringLis
 type ExpressRouteCircuitPeeringPropertiesFormat struct {
 	PeeringType                ExpressRouteCircuitPeeringType    `json:"peeringType,omitempty"`
 	State                      ExpressRouteCircuitPeeringState   `json:"state,omitempty"`
-	AzureASN                   *int                              `json:"azureASN,omitempty"`
-	PeerASN                    *int                              `json:"peerASN,omitempty"`
+	AzureASN                   *int32                            `json:"azureASN,omitempty"`
+	PeerASN                    *int32                            `json:"peerASN,omitempty"`
 	PrimaryPeerAddressPrefix   *string                           `json:"primaryPeerAddressPrefix,omitempty"`
 	SecondaryPeerAddressPrefix *string                           `json:"secondaryPeerAddressPrefix,omitempty"`
 	PrimaryAzurePort           *string                           `json:"primaryAzurePort,omitempty"`
 	SecondaryAzurePort         *string                           `json:"secondaryAzurePort,omitempty"`
 	SharedKey                  *string                           `json:"sharedKey,omitempty"`
-	VlanID                     *int                              `json:"vlanId,omitempty"`
+	VlanID                     *int32                            `json:"vlanId,omitempty"`
 	MicrosoftPeeringConfig     *ExpressRouteCircuitPeeringConfig `json:"microsoftPeeringConfig,omitempty"`
 	Stats                      *ExpressRouteCircuitStats         `json:"stats,omitempty"`
 	ProvisioningState          *string                           `json:"provisioningState,omitempty"`
@@ -956,7 +956,7 @@ func (client ExpressRouteCircuitsArpTableListResult) ExpressRouteCircuitsArpTabl
 type ExpressRouteCircuitServiceProviderProperties struct {
 	ServiceProviderName *string `json:"serviceProviderName,omitempty"`
 	PeeringLocation     *string `json:"peeringLocation,omitempty"`
-	BandwidthInMbps     *int    `json:"bandwidthInMbps,omitempty"`
+	BandwidthInMbps     *int32  `json:"bandwidthInMbps,omitempty"`
 }
 
 // ExpressRouteCircuitSku is contains sku in an ExpressRouteCircuit
@@ -1008,8 +1008,8 @@ func (client ExpressRouteCircuitsStatsListResult) ExpressRouteCircuitsStatsListR
 
 // ExpressRouteCircuitStats is contains Stats associated with the peering
 type ExpressRouteCircuitStats struct {
-	BytesIn  *int `json:"bytesIn,omitempty"`
-	BytesOut *int `json:"bytesOut,omitempty"`
+	BytesIn  *int32 `json:"bytesIn,omitempty"`
+	BytesOut *int32 `json:"bytesOut,omitempty"`
 }
 
 // ExpressRouteServiceProvider is expressRouteResourceProvider object
@@ -1026,7 +1026,7 @@ type ExpressRouteServiceProvider struct {
 // in ExpressRouteServiceProviders
 type ExpressRouteServiceProviderBandwidthsOffered struct {
 	OfferName   *string `json:"offerName,omitempty"`
-	ValueInMbps *int    `json:"valueInMbps,omitempty"`
+	ValueInMbps *int32  `json:"valueInMbps,omitempty"`
 }
 
 // ExpressRouteServiceProviderListResult is response for
@@ -1091,9 +1091,9 @@ type InboundNatPool struct {
 type InboundNatPoolPropertiesFormat struct {
 	FrontendIPConfiguration *SubResource      `json:"frontendIPConfiguration,omitempty"`
 	Protocol                TransportProtocol `json:"protocol,omitempty"`
-	FrontendPortRangeStart  *int              `json:"frontendPortRangeStart,omitempty"`
-	FrontendPortRangeEnd    *int              `json:"frontendPortRangeEnd,omitempty"`
-	BackendPort             *int              `json:"backendPort,omitempty"`
+	FrontendPortRangeStart  *int32            `json:"frontendPortRangeStart,omitempty"`
+	FrontendPortRangeEnd    *int32            `json:"frontendPortRangeEnd,omitempty"`
+	BackendPort             *int32            `json:"backendPort,omitempty"`
 	ProvisioningState       *string           `json:"provisioningState,omitempty"`
 }
 
@@ -1110,9 +1110,9 @@ type InboundNatRulePropertiesFormat struct {
 	FrontendIPConfiguration *SubResource              `json:"frontendIPConfiguration,omitempty"`
 	BackendIPConfiguration  *InterfaceIPConfiguration `json:"backendIPConfiguration,omitempty"`
 	Protocol                TransportProtocol         `json:"protocol,omitempty"`
-	FrontendPort            *int                      `json:"frontendPort,omitempty"`
-	BackendPort             *int                      `json:"backendPort,omitempty"`
-	IdleTimeoutInMinutes    *int                      `json:"idleTimeoutInMinutes,omitempty"`
+	FrontendPort            *int32                    `json:"frontendPort,omitempty"`
+	BackendPort             *int32                    `json:"backendPort,omitempty"`
+	IdleTimeoutInMinutes    *int32                    `json:"idleTimeoutInMinutes,omitempty"`
 	EnableFloatingIP        *bool                     `json:"enableFloatingIP,omitempty"`
 	ProvisioningState       *string                   `json:"provisioningState,omitempty"`
 }
@@ -1264,9 +1264,9 @@ type LoadBalancingRulePropertiesFormat struct {
 	Probe                   *SubResource      `json:"probe,omitempty"`
 	Protocol                TransportProtocol `json:"protocol,omitempty"`
 	LoadDistribution        LoadDistribution  `json:"loadDistribution,omitempty"`
-	FrontendPort            *int              `json:"frontendPort,omitempty"`
-	BackendPort             *int              `json:"backendPort,omitempty"`
-	IdleTimeoutInMinutes    *int              `json:"idleTimeoutInMinutes,omitempty"`
+	FrontendPort            *int32            `json:"frontendPort,omitempty"`
+	BackendPort             *int32            `json:"backendPort,omitempty"`
+	IdleTimeoutInMinutes    *int32            `json:"idleTimeoutInMinutes,omitempty"`
 	EnableFloatingIP        *bool             `json:"enableFloatingIP,omitempty"`
 	ProvisioningState       *string           `json:"provisioningState,omitempty"`
 }
@@ -1321,7 +1321,7 @@ type OutboundNatRule struct {
 
 // OutboundNatRulePropertiesFormat is outbound NAT pool of the loadbalancer
 type OutboundNatRulePropertiesFormat struct {
-	AllocatedOutboundPorts   *int           `json:"allocatedOutboundPorts,omitempty"`
+	AllocatedOutboundPorts   *int32         `json:"allocatedOutboundPorts,omitempty"`
 	FrontendIPConfigurations *[]SubResource `json:"frontendIPConfigurations,omitempty"`
 	BackendAddressPool       *SubResource   `json:"backendAddressPool,omitempty"`
 	ProvisioningState        *string        `json:"provisioningState,omitempty"`
@@ -1339,9 +1339,9 @@ type Probe struct {
 type ProbePropertiesFormat struct {
 	LoadBalancingRules *[]SubResource `json:"loadBalancingRules,omitempty"`
 	Protocol           ProbeProtocol  `json:"protocol,omitempty"`
-	Port               *int           `json:"port,omitempty"`
-	IntervalInSeconds  *int           `json:"intervalInSeconds,omitempty"`
-	NumberOfProbes     *int           `json:"numberOfProbes,omitempty"`
+	Port               *int32         `json:"port,omitempty"`
+	IntervalInSeconds  *int32         `json:"intervalInSeconds,omitempty"`
+	NumberOfProbes     *int32         `json:"numberOfProbes,omitempty"`
 	RequestPath        *string        `json:"requestPath,omitempty"`
 	ProvisioningState  *string        `json:"provisioningState,omitempty"`
 }
@@ -1392,7 +1392,7 @@ type PublicIPAddressPropertiesFormat struct {
 	IPConfiguration          *IPConfiguration            `json:"ipConfiguration,omitempty"`
 	DNSSettings              *PublicIPAddressDNSSettings `json:"dnsSettings,omitempty"`
 	IPAddress                *string                     `json:"ipAddress,omitempty"`
-	IdleTimeoutInMinutes     *int                        `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes     *int32                      `json:"idleTimeoutInMinutes,omitempty"`
 	ResourceGUID             *string                     `json:"resourceGuid,omitempty"`
 	ProvisioningState        *string                     `json:"provisioningState,omitempty"`
 }
@@ -1560,7 +1560,7 @@ type SecurityRulePropertiesFormat struct {
 	SourceAddressPrefix      *string               `json:"sourceAddressPrefix,omitempty"`
 	DestinationAddressPrefix *string               `json:"destinationAddressPrefix,omitempty"`
 	Access                   SecurityRuleAccess    `json:"access,omitempty"`
-	Priority                 *int                  `json:"priority,omitempty"`
+	Priority                 *int32                `json:"priority,omitempty"`
 	Direction                SecurityRuleDirection `json:"direction,omitempty"`
 	ProvisioningState        *string               `json:"provisioningState,omitempty"`
 }
@@ -1617,8 +1617,8 @@ type SubResource struct {
 // Usage is describes Network Resource Usage.
 type Usage struct {
 	Unit         UsageUnit  `json:"unit,omitempty"`
-	CurrentValue *int32     `json:"currentValue,omitempty"`
-	Limit        *int32     `json:"limit,omitempty"`
+	CurrentValue *int64     `json:"currentValue,omitempty"`
+	Limit        *int64     `json:"limit,omitempty"`
 	Name         *UsageName `json:"name,omitempty"`
 }
 
@@ -1712,11 +1712,11 @@ type VirtualNetworkGatewayConnectionPropertiesFormat struct {
 	VirtualNetworkGateway2  *VirtualNetworkGateway                `json:"virtualNetworkGateway2,omitempty"`
 	LocalNetworkGateway2    *LocalNetworkGateway                  `json:"localNetworkGateway2,omitempty"`
 	ConnectionType          VirtualNetworkGatewayConnectionType   `json:"connectionType,omitempty"`
-	RoutingWeight           *int                                  `json:"routingWeight,omitempty"`
+	RoutingWeight           *int32                                `json:"routingWeight,omitempty"`
 	SharedKey               *string                               `json:"sharedKey,omitempty"`
 	ConnectionStatus        VirtualNetworkGatewayConnectionStatus `json:"connectionStatus,omitempty"`
-	EgressBytesTransferred  *int32                                `json:"egressBytesTransferred,omitempty"`
-	IngressBytesTransferred *int32                                `json:"ingressBytesTransferred,omitempty"`
+	EgressBytesTransferred  *int64                                `json:"egressBytesTransferred,omitempty"`
+	IngressBytesTransferred *int64                                `json:"ingressBytesTransferred,omitempty"`
 	Peer                    *SubResource                          `json:"peer,omitempty"`
 	ResourceGUID            *string                               `json:"resourceGuid,omitempty"`
 	ProvisioningState       *string                               `json:"provisioningState,omitempty"`
@@ -1778,7 +1778,7 @@ type VirtualNetworkGatewayPropertiesFormat struct {
 type VirtualNetworkGatewaySku struct {
 	Name     VirtualNetworkGatewaySkuName `json:"name,omitempty"`
 	Tier     VirtualNetworkGatewaySkuTier `json:"tier,omitempty"`
-	Capacity *int                         `json:"capacity,omitempty"`
+	Capacity *int32                       `json:"capacity,omitempty"`
 }
 
 // VirtualNetworkListResult is response for ListVirtualNetworks Api servive

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/publicipaddresses.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/publicipaddresses.go
@@ -47,33 +47,35 @@ func NewPublicIPAddressesClientWithBaseURI(baseURI string, subscriptionID string
 }
 
 // CreateOrUpdate the Put PublicIPAddress operation creates/updates a
-// stable/dynamic PublicIP address
+// stable/dynamic PublicIP address This method may poll for completion.
+// Polling can be canceled by passing the cancel channel argument. The
+// channel will be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. publicIPAddressName is
 // the name of the publicIpAddress. parameters is parameters supplied to the
 // create/update PublicIPAddress operation
-func (client PublicIPAddressesClient) CreateOrUpdate(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (result PublicIPAddress, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, publicIPAddressName, parameters)
+func (client PublicIPAddressesClient) CreateOrUpdate(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, publicIPAddressName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client PublicIPAddressesClient) CreateOrUpdatePreparer(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (*http.Request, error) {
+func (client PublicIPAddressesClient) CreateOrUpdatePreparer(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"publicIpAddressName": url.QueryEscape(publicIPAddressName),
 		"resourceGroupName":   url.QueryEscape(resourceGroupName),
@@ -84,7 +86,7 @@ func (client PublicIPAddressesClient) CreateOrUpdatePreparer(resourceGroupName s
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -97,29 +99,32 @@ func (client PublicIPAddressesClient) CreateOrUpdatePreparer(resourceGroupName s
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client PublicIPAddressesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client PublicIPAddressesClient) CreateOrUpdateResponder(resp *http.Response) (result PublicIPAddress, err error) {
+func (client PublicIPAddressesClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the delete publicIpAddress operation deletes the specified
-// publicIpAddress.
+// publicIpAddress. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. publicIPAddressName is
 // the name of the subnet.
-func (client PublicIPAddressesClient) Delete(resourceGroupName string, publicIPAddressName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, publicIPAddressName)
+func (client PublicIPAddressesClient) Delete(resourceGroupName string, publicIPAddressName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, publicIPAddressName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -132,14 +137,14 @@ func (client PublicIPAddressesClient) Delete(resourceGroupName string, publicIPA
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client PublicIPAddressesClient) DeletePreparer(resourceGroupName string, publicIPAddressName string) (*http.Request, error) {
+func (client PublicIPAddressesClient) DeletePreparer(resourceGroupName string, publicIPAddressName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"publicIpAddressName": url.QueryEscape(publicIPAddressName),
 		"resourceGroupName":   url.QueryEscape(resourceGroupName),
@@ -150,7 +155,7 @@ func (client PublicIPAddressesClient) DeletePreparer(resourceGroupName string, p
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -162,7 +167,9 @@ func (client PublicIPAddressesClient) DeletePreparer(resourceGroupName string, p
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client PublicIPAddressesClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -182,7 +189,7 @@ func (client PublicIPAddressesClient) DeleteResponder(resp *http.Response) (resu
 //
 // resourceGroupName is the name of the resource group. publicIPAddressName is
 // the name of the subnet. expand is expand references resources.
-func (client PublicIPAddressesClient) Get(resourceGroupName string, publicIPAddressName string, expand string) (result PublicIPAddress, ae error) {
+func (client PublicIPAddressesClient) Get(resourceGroupName string, publicIPAddressName string, expand string) (result PublicIPAddress, err error) {
 	req, err := client.GetPreparer(resourceGroupName, publicIPAddressName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Get", nil, "Failure preparing request")
@@ -196,7 +203,7 @@ func (client PublicIPAddressesClient) Get(resourceGroupName string, publicIPAddr
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -229,7 +236,7 @@ func (client PublicIPAddressesClient) GetPreparer(resourceGroupName string, publ
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client PublicIPAddressesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -249,7 +256,7 @@ func (client PublicIPAddressesClient) GetResponder(resp *http.Response) (result 
 // in a resource group.
 //
 // resourceGroupName is the name of the resource group.
-func (client PublicIPAddressesClient) List(resourceGroupName string) (result PublicIPAddressListResult, ae error) {
+func (client PublicIPAddressesClient) List(resourceGroupName string) (result PublicIPAddressListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "List", nil, "Failure preparing request")
@@ -263,7 +270,7 @@ func (client PublicIPAddressesClient) List(resourceGroupName string) (result Pub
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -292,7 +299,7 @@ func (client PublicIPAddressesClient) ListPreparer(resourceGroupName string) (*h
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client PublicIPAddressesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -309,7 +316,7 @@ func (client PublicIPAddressesClient) ListResponder(resp *http.Response) (result
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client PublicIPAddressesClient) ListNextResults(lastResults PublicIPAddressListResult) (result PublicIPAddressListResult, ae error) {
+func (client PublicIPAddressesClient) ListNextResults(lastResults PublicIPAddressListResult) (result PublicIPAddressListResult, err error) {
 	req, err := lastResults.PublicIPAddressListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "List", nil, "Failure preparing next results request request")
@@ -326,7 +333,7 @@ func (client PublicIPAddressesClient) ListNextResults(lastResults PublicIPAddres
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -334,7 +341,7 @@ func (client PublicIPAddressesClient) ListNextResults(lastResults PublicIPAddres
 
 // ListAll the List publicIpAddress opertion retrieves all the
 // publicIpAddresses in a subscription.
-func (client PublicIPAddressesClient) ListAll() (result PublicIPAddressListResult, ae error) {
+func (client PublicIPAddressesClient) ListAll() (result PublicIPAddressListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "ListAll", nil, "Failure preparing request")
@@ -348,7 +355,7 @@ func (client PublicIPAddressesClient) ListAll() (result PublicIPAddressListResul
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -376,7 +383,7 @@ func (client PublicIPAddressesClient) ListAllPreparer() (*http.Request, error) {
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client PublicIPAddressesClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -393,7 +400,7 @@ func (client PublicIPAddressesClient) ListAllResponder(resp *http.Response) (res
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client PublicIPAddressesClient) ListAllNextResults(lastResults PublicIPAddressListResult) (result PublicIPAddressListResult, ae error) {
+func (client PublicIPAddressesClient) ListAllNextResults(lastResults PublicIPAddressListResult) (result PublicIPAddressListResult, err error) {
 	req, err := lastResults.PublicIPAddressListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "ListAll", nil, "Failure preparing next results request request")
@@ -410,7 +417,7 @@ func (client PublicIPAddressesClient) ListAllNextResults(lastResults PublicIPAdd
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/routes.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/routes.go
@@ -45,33 +45,35 @@ func NewRoutesClientWithBaseURI(baseURI string, subscriptionID string) RoutesCli
 }
 
 // CreateOrUpdate the Put route operation creates/updates a route in the
-// specified route table
+// specified route table This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table. routeName is the name of the route.
 // routeParameters is parameters supplied to the create/update routeoperation
-func (client RoutesClient) CreateOrUpdate(resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (result Route, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, routeTableName, routeName, routeParameters)
+func (client RoutesClient) CreateOrUpdate(resourceGroupName string, routeTableName string, routeName string, routeParameters Route, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, routeTableName, routeName, routeParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RoutesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/RoutesClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RoutesClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RoutesClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client RoutesClient) CreateOrUpdatePreparer(resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (*http.Request, error) {
+func (client RoutesClient) CreateOrUpdatePreparer(resourceGroupName string, routeTableName string, routeName string, routeParameters Route, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"routeName":         url.QueryEscape(routeName),
@@ -83,7 +85,7 @@ func (client RoutesClient) CreateOrUpdatePreparer(resourceGroupName string, rout
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -96,29 +98,32 @@ func (client RoutesClient) CreateOrUpdatePreparer(resourceGroupName string, rout
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client RoutesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client RoutesClient) CreateOrUpdateResponder(resp *http.Response) (result Route, err error) {
+func (client RoutesClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the delete route operation deletes the specified route from a route
-// table.
+// table. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table. routeName is the name of the route.
-func (client RoutesClient) Delete(resourceGroupName string, routeTableName string, routeName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, routeTableName, routeName)
+func (client RoutesClient) Delete(resourceGroupName string, routeTableName string, routeName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, routeTableName, routeName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RoutesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -131,14 +136,14 @@ func (client RoutesClient) Delete(resourceGroupName string, routeTableName strin
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RoutesClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RoutesClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client RoutesClient) DeletePreparer(resourceGroupName string, routeTableName string, routeName string) (*http.Request, error) {
+func (client RoutesClient) DeletePreparer(resourceGroupName string, routeTableName string, routeName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"routeName":         url.QueryEscape(routeName),
@@ -150,7 +155,7 @@ func (client RoutesClient) DeletePreparer(resourceGroupName string, routeTableNa
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -162,7 +167,9 @@ func (client RoutesClient) DeletePreparer(resourceGroupName string, routeTableNa
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client RoutesClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -182,7 +189,7 @@ func (client RoutesClient) DeleteResponder(resp *http.Response) (result autorest
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table. routeName is the name of the route.
-func (client RoutesClient) Get(resourceGroupName string, routeTableName string, routeName string) (result Route, ae error) {
+func (client RoutesClient) Get(resourceGroupName string, routeTableName string, routeName string) (result Route, err error) {
 	req, err := client.GetPreparer(resourceGroupName, routeTableName, routeName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RoutesClient", "Get", nil, "Failure preparing request")
@@ -196,7 +203,7 @@ func (client RoutesClient) Get(resourceGroupName string, routeTableName string, 
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RoutesClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RoutesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -227,7 +234,7 @@ func (client RoutesClient) GetPreparer(resourceGroupName string, routeTableName 
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client RoutesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -248,7 +255,7 @@ func (client RoutesClient) GetResponder(resp *http.Response) (result Route, err 
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table.
-func (client RoutesClient) List(resourceGroupName string, routeTableName string) (result RouteListResult, ae error) {
+func (client RoutesClient) List(resourceGroupName string, routeTableName string) (result RouteListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName, routeTableName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RoutesClient", "List", nil, "Failure preparing request")
@@ -262,7 +269,7 @@ func (client RoutesClient) List(resourceGroupName string, routeTableName string)
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RoutesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RoutesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -292,7 +299,7 @@ func (client RoutesClient) ListPreparer(resourceGroupName string, routeTableName
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client RoutesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -309,7 +316,7 @@ func (client RoutesClient) ListResponder(resp *http.Response) (result RouteListR
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client RoutesClient) ListNextResults(lastResults RouteListResult) (result RouteListResult, ae error) {
+func (client RoutesClient) ListNextResults(lastResults RouteListResult) (result RouteListResult, err error) {
 	req, err := lastResults.RouteListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RoutesClient", "List", nil, "Failure preparing next results request request")
@@ -326,7 +333,7 @@ func (client RoutesClient) ListNextResults(lastResults RouteListResult) (result 
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RoutesClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/RoutesClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/routetables.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/routetables.go
@@ -46,33 +46,35 @@ func NewRouteTablesClientWithBaseURI(baseURI string, subscriptionID string) Rout
 }
 
 // CreateOrUpdate the Put RouteTable operation creates/updates a route tablein
-// the specified resource group.
+// the specified resource group. This method may poll for completion. Polling
+// can be canceled by passing the cancel channel argument. The channel will
+// be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table. parameters is parameters supplied to the
 // create/update Route Table operation
-func (client RouteTablesClient) CreateOrUpdate(resourceGroupName string, routeTableName string, parameters RouteTable) (result RouteTable, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, routeTableName, parameters)
+func (client RouteTablesClient) CreateOrUpdate(resourceGroupName string, routeTableName string, parameters RouteTable, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, routeTableName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RouteTablesClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RouteTablesClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client RouteTablesClient) CreateOrUpdatePreparer(resourceGroupName string, routeTableName string, parameters RouteTable) (*http.Request, error) {
+func (client RouteTablesClient) CreateOrUpdatePreparer(resourceGroupName string, routeTableName string, parameters RouteTable, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"routeTableName":    url.QueryEscape(routeTableName),
@@ -83,7 +85,7 @@ func (client RouteTablesClient) CreateOrUpdatePreparer(resourceGroupName string,
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -96,28 +98,32 @@ func (client RouteTablesClient) CreateOrUpdatePreparer(resourceGroupName string,
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client RouteTablesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client RouteTablesClient) CreateOrUpdateResponder(resp *http.Response) (result RouteTable, err error) {
+func (client RouteTablesClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the Delete RouteTable operation deletes the specifed Route Table
+// This method may poll for completion. Polling can be canceled by passing
+// the cancel channel argument. The channel will be used to cancel polling
+// and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table.
-func (client RouteTablesClient) Delete(resourceGroupName string, routeTableName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, routeTableName)
+func (client RouteTablesClient) Delete(resourceGroupName string, routeTableName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, routeTableName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -130,14 +136,14 @@ func (client RouteTablesClient) Delete(resourceGroupName string, routeTableName 
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RouteTablesClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RouteTablesClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client RouteTablesClient) DeletePreparer(resourceGroupName string, routeTableName string) (*http.Request, error) {
+func (client RouteTablesClient) DeletePreparer(resourceGroupName string, routeTableName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"routeTableName":    url.QueryEscape(routeTableName),
@@ -148,7 +154,7 @@ func (client RouteTablesClient) DeletePreparer(resourceGroupName string, routeTa
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -160,7 +166,9 @@ func (client RouteTablesClient) DeletePreparer(resourceGroupName string, routeTa
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client RouteTablesClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -180,7 +188,7 @@ func (client RouteTablesClient) DeleteResponder(resp *http.Response) (result aut
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table. expand is expand references resources.
-func (client RouteTablesClient) Get(resourceGroupName string, routeTableName string, expand string) (result RouteTable, ae error) {
+func (client RouteTablesClient) Get(resourceGroupName string, routeTableName string, expand string) (result RouteTable, err error) {
 	req, err := client.GetPreparer(resourceGroupName, routeTableName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "Get", nil, "Failure preparing request")
@@ -194,7 +202,7 @@ func (client RouteTablesClient) Get(resourceGroupName string, routeTableName str
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RouteTablesClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RouteTablesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -227,7 +235,7 @@ func (client RouteTablesClient) GetPreparer(resourceGroupName string, routeTable
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client RouteTablesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -246,7 +254,7 @@ func (client RouteTablesClient) GetResponder(resp *http.Response) (result RouteT
 // List the list RouteTables returns all route tables in a resource group
 //
 // resourceGroupName is the name of the resource group.
-func (client RouteTablesClient) List(resourceGroupName string) (result RouteTableListResult, ae error) {
+func (client RouteTablesClient) List(resourceGroupName string) (result RouteTableListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "List", nil, "Failure preparing request")
@@ -260,7 +268,7 @@ func (client RouteTablesClient) List(resourceGroupName string) (result RouteTabl
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RouteTablesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RouteTablesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -289,7 +297,7 @@ func (client RouteTablesClient) ListPreparer(resourceGroupName string) (*http.Re
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client RouteTablesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -306,7 +314,7 @@ func (client RouteTablesClient) ListResponder(resp *http.Response) (result Route
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client RouteTablesClient) ListNextResults(lastResults RouteTableListResult) (result RouteTableListResult, ae error) {
+func (client RouteTablesClient) ListNextResults(lastResults RouteTableListResult) (result RouteTableListResult, err error) {
 	req, err := lastResults.RouteTableListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "List", nil, "Failure preparing next results request request")
@@ -323,14 +331,14 @@ func (client RouteTablesClient) ListNextResults(lastResults RouteTableListResult
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RouteTablesClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/RouteTablesClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
 }
 
 // ListAll the list RouteTables returns all route tables in a subscription
-func (client RouteTablesClient) ListAll() (result RouteTableListResult, ae error) {
+func (client RouteTablesClient) ListAll() (result RouteTableListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "ListAll", nil, "Failure preparing request")
@@ -344,7 +352,7 @@ func (client RouteTablesClient) ListAll() (result RouteTableListResult, ae error
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RouteTablesClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/RouteTablesClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -372,7 +380,7 @@ func (client RouteTablesClient) ListAllPreparer() (*http.Request, error) {
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client RouteTablesClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -389,7 +397,7 @@ func (client RouteTablesClient) ListAllResponder(resp *http.Response) (result Ro
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client RouteTablesClient) ListAllNextResults(lastResults RouteTableListResult) (result RouteTableListResult, ae error) {
+func (client RouteTablesClient) ListAllNextResults(lastResults RouteTableListResult) (result RouteTableListResult, err error) {
 	req, err := lastResults.RouteTableListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "ListAll", nil, "Failure preparing next results request request")
@@ -406,7 +414,7 @@ func (client RouteTablesClient) ListAllNextResults(lastResults RouteTableListRes
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/RouteTablesClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/RouteTablesClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/securitygroups.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/securitygroups.go
@@ -47,34 +47,37 @@ func NewSecurityGroupsClientWithBaseURI(baseURI string, subscriptionID string) S
 }
 
 // CreateOrUpdate the Put NetworkSecurityGroup operation creates/updates a
-// network security groupin the specified resource group.
+// network security groupin the specified resource group. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
 // parameters is parameters supplied to the create/update Network Security
 // Group operation
-func (client SecurityGroupsClient) CreateOrUpdate(resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup) (result SecurityGroup, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkSecurityGroupName, parameters)
+func (client SecurityGroupsClient) CreateOrUpdate(resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkSecurityGroupName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client SecurityGroupsClient) CreateOrUpdatePreparer(resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup) (*http.Request, error) {
+func (client SecurityGroupsClient) CreateOrUpdatePreparer(resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkSecurityGroupName": url.QueryEscape(networkSecurityGroupName),
 		"resourceGroupName":        url.QueryEscape(resourceGroupName),
@@ -85,7 +88,7 @@ func (client SecurityGroupsClient) CreateOrUpdatePreparer(resourceGroupName stri
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -98,29 +101,32 @@ func (client SecurityGroupsClient) CreateOrUpdatePreparer(resourceGroupName stri
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityGroupsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client SecurityGroupsClient) CreateOrUpdateResponder(resp *http.Response) (result SecurityGroup, err error) {
+func (client SecurityGroupsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the Delete NetworkSecurityGroup operation deletes the specifed
-// network security group
+// network security group This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
-func (client SecurityGroupsClient) Delete(resourceGroupName string, networkSecurityGroupName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, networkSecurityGroupName)
+func (client SecurityGroupsClient) Delete(resourceGroupName string, networkSecurityGroupName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, networkSecurityGroupName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -133,14 +139,14 @@ func (client SecurityGroupsClient) Delete(resourceGroupName string, networkSecur
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client SecurityGroupsClient) DeletePreparer(resourceGroupName string, networkSecurityGroupName string) (*http.Request, error) {
+func (client SecurityGroupsClient) DeletePreparer(resourceGroupName string, networkSecurityGroupName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkSecurityGroupName": url.QueryEscape(networkSecurityGroupName),
 		"resourceGroupName":        url.QueryEscape(resourceGroupName),
@@ -151,7 +157,7 @@ func (client SecurityGroupsClient) DeletePreparer(resourceGroupName string, netw
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -163,7 +169,9 @@ func (client SecurityGroupsClient) DeletePreparer(resourceGroupName string, netw
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityGroupsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -184,7 +192,7 @@ func (client SecurityGroupsClient) DeleteResponder(resp *http.Response) (result 
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group. expand
 // is expand references resources.
-func (client SecurityGroupsClient) Get(resourceGroupName string, networkSecurityGroupName string, expand string) (result SecurityGroup, ae error) {
+func (client SecurityGroupsClient) Get(resourceGroupName string, networkSecurityGroupName string, expand string) (result SecurityGroup, err error) {
 	req, err := client.GetPreparer(resourceGroupName, networkSecurityGroupName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Get", nil, "Failure preparing request")
@@ -198,7 +206,7 @@ func (client SecurityGroupsClient) Get(resourceGroupName string, networkSecurity
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -231,7 +239,7 @@ func (client SecurityGroupsClient) GetPreparer(resourceGroupName string, network
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityGroupsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -251,7 +259,7 @@ func (client SecurityGroupsClient) GetResponder(resp *http.Response) (result Sec
 // a resource group
 //
 // resourceGroupName is the name of the resource group.
-func (client SecurityGroupsClient) List(resourceGroupName string) (result SecurityGroupListResult, ae error) {
+func (client SecurityGroupsClient) List(resourceGroupName string) (result SecurityGroupListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "List", nil, "Failure preparing request")
@@ -265,7 +273,7 @@ func (client SecurityGroupsClient) List(resourceGroupName string) (result Securi
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -294,7 +302,7 @@ func (client SecurityGroupsClient) ListPreparer(resourceGroupName string) (*http
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityGroupsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -311,7 +319,7 @@ func (client SecurityGroupsClient) ListResponder(resp *http.Response) (result Se
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client SecurityGroupsClient) ListNextResults(lastResults SecurityGroupListResult) (result SecurityGroupListResult, ae error) {
+func (client SecurityGroupsClient) ListNextResults(lastResults SecurityGroupListResult) (result SecurityGroupListResult, err error) {
 	req, err := lastResults.SecurityGroupListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "List", nil, "Failure preparing next results request request")
@@ -328,7 +336,7 @@ func (client SecurityGroupsClient) ListNextResults(lastResults SecurityGroupList
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -336,7 +344,7 @@ func (client SecurityGroupsClient) ListNextResults(lastResults SecurityGroupList
 
 // ListAll the list NetworkSecurityGroups returns all network security groups
 // in a subscription
-func (client SecurityGroupsClient) ListAll() (result SecurityGroupListResult, ae error) {
+func (client SecurityGroupsClient) ListAll() (result SecurityGroupListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "ListAll", nil, "Failure preparing request")
@@ -350,7 +358,7 @@ func (client SecurityGroupsClient) ListAll() (result SecurityGroupListResult, ae
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -378,7 +386,7 @@ func (client SecurityGroupsClient) ListAllPreparer() (*http.Request, error) {
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityGroupsClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -395,7 +403,7 @@ func (client SecurityGroupsClient) ListAllResponder(resp *http.Response) (result
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client SecurityGroupsClient) ListAllNextResults(lastResults SecurityGroupListResult) (result SecurityGroupListResult, ae error) {
+func (client SecurityGroupsClient) ListAllNextResults(lastResults SecurityGroupListResult) (result SecurityGroupListResult, err error) {
 	req, err := lastResults.SecurityGroupListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "ListAll", nil, "Failure preparing next results request request")
@@ -412,7 +420,7 @@ func (client SecurityGroupsClient) ListAllNextResults(lastResults SecurityGroupL
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/securityrules.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/securityrules.go
@@ -47,35 +47,38 @@ func NewSecurityRulesClientWithBaseURI(baseURI string, subscriptionID string) Se
 }
 
 // CreateOrUpdate the Put network security rule operation creates/updates a
-// security rule in the specified network security group
+// security rule in the specified network security group This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
 // securityRuleName is the name of the security rule. securityRuleParameters
 // is parameters supplied to the create/update network security rule
 // operation
-func (client SecurityRulesClient) CreateOrUpdate(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (result SecurityRule, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters)
+func (client SecurityRulesClient) CreateOrUpdate(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client SecurityRulesClient) CreateOrUpdatePreparer(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (*http.Request, error) {
+func (client SecurityRulesClient) CreateOrUpdatePreparer(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkSecurityGroupName": url.QueryEscape(networkSecurityGroupName),
 		"resourceGroupName":        url.QueryEscape(resourceGroupName),
@@ -87,7 +90,7 @@ func (client SecurityRulesClient) CreateOrUpdatePreparer(resourceGroupName strin
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -100,30 +103,33 @@ func (client SecurityRulesClient) CreateOrUpdatePreparer(resourceGroupName strin
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityRulesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client SecurityRulesClient) CreateOrUpdateResponder(resp *http.Response) (result SecurityRule, err error) {
+func (client SecurityRulesClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the delete network security rule operation deletes the specified
-// network security rule.
+// network security rule. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
 // securityRuleName is the name of the security rule.
-func (client SecurityRulesClient) Delete(resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, networkSecurityGroupName, securityRuleName)
+func (client SecurityRulesClient) Delete(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, networkSecurityGroupName, securityRuleName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -136,14 +142,14 @@ func (client SecurityRulesClient) Delete(resourceGroupName string, networkSecuri
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client SecurityRulesClient) DeletePreparer(resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*http.Request, error) {
+func (client SecurityRulesClient) DeletePreparer(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkSecurityGroupName": url.QueryEscape(networkSecurityGroupName),
 		"resourceGroupName":        url.QueryEscape(resourceGroupName),
@@ -155,7 +161,7 @@ func (client SecurityRulesClient) DeletePreparer(resourceGroupName string, netwo
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -167,7 +173,9 @@ func (client SecurityRulesClient) DeletePreparer(resourceGroupName string, netwo
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityRulesClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -188,7 +196,7 @@ func (client SecurityRulesClient) DeleteResponder(resp *http.Response) (result a
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
 // securityRuleName is the name of the security rule.
-func (client SecurityRulesClient) Get(resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (result SecurityRule, ae error) {
+func (client SecurityRulesClient) Get(resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (result SecurityRule, err error) {
 	req, err := client.GetPreparer(resourceGroupName, networkSecurityGroupName, securityRuleName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Get", nil, "Failure preparing request")
@@ -202,7 +210,7 @@ func (client SecurityRulesClient) Get(resourceGroupName string, networkSecurityG
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -233,7 +241,7 @@ func (client SecurityRulesClient) GetPreparer(resourceGroupName string, networkS
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityRulesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -254,7 +262,7 @@ func (client SecurityRulesClient) GetResponder(resp *http.Response) (result Secu
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
-func (client SecurityRulesClient) List(resourceGroupName string, networkSecurityGroupName string) (result SecurityRuleListResult, ae error) {
+func (client SecurityRulesClient) List(resourceGroupName string, networkSecurityGroupName string) (result SecurityRuleListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName, networkSecurityGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "List", nil, "Failure preparing request")
@@ -268,7 +276,7 @@ func (client SecurityRulesClient) List(resourceGroupName string, networkSecurity
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -298,7 +306,7 @@ func (client SecurityRulesClient) ListPreparer(resourceGroupName string, network
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client SecurityRulesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -315,7 +323,7 @@ func (client SecurityRulesClient) ListResponder(resp *http.Response) (result Sec
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client SecurityRulesClient) ListNextResults(lastResults SecurityRuleListResult) (result SecurityRuleListResult, ae error) {
+func (client SecurityRulesClient) ListNextResults(lastResults SecurityRuleListResult) (result SecurityRuleListResult, err error) {
 	req, err := lastResults.SecurityRuleListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "List", nil, "Failure preparing next results request request")
@@ -332,7 +340,7 @@ func (client SecurityRulesClient) ListNextResults(lastResults SecurityRuleListRe
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/SecurityRulesClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/subnets.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/subnets.go
@@ -45,34 +45,36 @@ func NewSubnetsClientWithBaseURI(baseURI string, subscriptionID string) SubnetsC
 }
 
 // CreateOrUpdate the Put Subnet operation creates/updates a subnet in
-// thespecified virtual network
+// thespecified virtual network This method may poll for completion. Polling
+// can be canceled by passing the cancel channel argument. The channel will
+// be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network. subnetName is the name of the subnet.
 // subnetParameters is parameters supplied to the create/update Subnet
 // operation
-func (client SubnetsClient) CreateOrUpdate(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (result Subnet, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkName, subnetName, subnetParameters)
+func (client SubnetsClient) CreateOrUpdate(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkName, subnetName, subnetParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SubnetsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SubnetsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client SubnetsClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (*http.Request, error) {
+func (client SubnetsClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":  url.QueryEscape(resourceGroupName),
 		"subnetName":         url.QueryEscape(subnetName),
@@ -84,7 +86,7 @@ func (client SubnetsClient) CreateOrUpdatePreparer(resourceGroupName string, vir
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -97,28 +99,32 @@ func (client SubnetsClient) CreateOrUpdatePreparer(resourceGroupName string, vir
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client SubnetsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client SubnetsClient) CreateOrUpdateResponder(resp *http.Response) (result Subnet, err error) {
+func (client SubnetsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
-// Delete the delete subnet operation deletes the specified subnet.
+// Delete the delete subnet operation deletes the specified subnet. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network. subnetName is the name of the subnet.
-func (client SubnetsClient) Delete(resourceGroupName string, virtualNetworkName string, subnetName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkName, subnetName)
+func (client SubnetsClient) Delete(resourceGroupName string, virtualNetworkName string, subnetName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkName, subnetName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -131,14 +137,14 @@ func (client SubnetsClient) Delete(resourceGroupName string, virtualNetworkName 
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SubnetsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SubnetsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client SubnetsClient) DeletePreparer(resourceGroupName string, virtualNetworkName string, subnetName string) (*http.Request, error) {
+func (client SubnetsClient) DeletePreparer(resourceGroupName string, virtualNetworkName string, subnetName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":  url.QueryEscape(resourceGroupName),
 		"subnetName":         url.QueryEscape(subnetName),
@@ -150,7 +156,7 @@ func (client SubnetsClient) DeletePreparer(resourceGroupName string, virtualNetw
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -162,7 +168,9 @@ func (client SubnetsClient) DeletePreparer(resourceGroupName string, virtualNetw
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client SubnetsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -183,7 +191,7 @@ func (client SubnetsClient) DeleteResponder(resp *http.Response) (result autores
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network. subnetName is the name of the subnet.
 // expand is expand references resources.
-func (client SubnetsClient) Get(resourceGroupName string, virtualNetworkName string, subnetName string, expand string) (result Subnet, ae error) {
+func (client SubnetsClient) Get(resourceGroupName string, virtualNetworkName string, subnetName string, expand string) (result Subnet, err error) {
 	req, err := client.GetPreparer(resourceGroupName, virtualNetworkName, subnetName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "Get", nil, "Failure preparing request")
@@ -197,7 +205,7 @@ func (client SubnetsClient) Get(resourceGroupName string, virtualNetworkName str
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SubnetsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SubnetsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -231,7 +239,7 @@ func (client SubnetsClient) GetPreparer(resourceGroupName string, virtualNetwork
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client SubnetsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -252,7 +260,7 @@ func (client SubnetsClient) GetResponder(resp *http.Response) (result Subnet, er
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network.
-func (client SubnetsClient) List(resourceGroupName string, virtualNetworkName string) (result SubnetListResult, ae error) {
+func (client SubnetsClient) List(resourceGroupName string, virtualNetworkName string) (result SubnetListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName, virtualNetworkName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "List", nil, "Failure preparing request")
@@ -266,7 +274,7 @@ func (client SubnetsClient) List(resourceGroupName string, virtualNetworkName st
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SubnetsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/SubnetsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -296,7 +304,7 @@ func (client SubnetsClient) ListPreparer(resourceGroupName string, virtualNetwor
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client SubnetsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -313,7 +321,7 @@ func (client SubnetsClient) ListResponder(resp *http.Response) (result SubnetLis
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client SubnetsClient) ListNextResults(lastResults SubnetListResult) (result SubnetListResult, ae error) {
+func (client SubnetsClient) ListNextResults(lastResults SubnetListResult) (result SubnetListResult, err error) {
 	req, err := lastResults.SubnetListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "List", nil, "Failure preparing next results request request")
@@ -330,7 +338,7 @@ func (client SubnetsClient) ListNextResults(lastResults SubnetListResult) (resul
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/SubnetsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/SubnetsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/usages.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/usages.go
@@ -47,7 +47,7 @@ func NewUsagesClientWithBaseURI(baseURI string, subscriptionID string) UsagesCli
 // List lists compute usages for a subscription.
 //
 // location is the location upon which resource usage is queried.
-func (client UsagesClient) List(location string) (result UsagesListResult, ae error) {
+func (client UsagesClient) List(location string) (result UsagesListResult, err error) {
 	req, err := client.ListPreparer(location)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/UsagesClient", "List", nil, "Failure preparing request")
@@ -61,7 +61,7 @@ func (client UsagesClient) List(location string) (result UsagesListResult, ae er
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/UsagesClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/UsagesClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -90,7 +90,7 @@ func (client UsagesClient) ListPreparer(location string) (*http.Request, error) 
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client UsagesClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -107,7 +107,7 @@ func (client UsagesClient) ListResponder(resp *http.Response) (result UsagesList
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client UsagesClient) ListNextResults(lastResults UsagesListResult) (result UsagesListResult, ae error) {
+func (client UsagesClient) ListNextResults(lastResults UsagesListResult) (result UsagesListResult, err error) {
 	req, err := lastResults.UsagesListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/UsagesClient", "List", nil, "Failure preparing next results request request")
@@ -124,7 +124,7 @@ func (client UsagesClient) ListNextResults(lastResults UsagesListResult) (result
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/UsagesClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/UsagesClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "5"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworkgatewayconnections.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworkgatewayconnections.go
@@ -48,35 +48,38 @@ func NewVirtualNetworkGatewayConnectionsClientWithBaseURI(baseURI string, subscr
 
 // CreateOrUpdate the Put VirtualNetworkGatewayConnection operation
 // creates/updates a virtual network gateway connection in the specified
-// resource group through Network resource provider.
+// resource group through Network resource provider. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the name of the virtual network
 // gateway conenction. parameters is parameters supplied to the Begin Create
 // or update Virtual Network Gateway connection operation through Network
 // resource provider.
-func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (result VirtualNetworkGatewayConnection, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":                   url.QueryEscape(resourceGroupName),
 		"subscriptionId":                      url.QueryEscape(client.SubscriptionID),
@@ -87,7 +90,7 @@ func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdatePreparer(reso
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -100,31 +103,34 @@ func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdatePreparer(reso
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdateResponder(resp *http.Response) (result VirtualNetworkGatewayConnection, err error) {
+func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the Delete VirtualNetworkGatewayConnection operation deletes the
 // specifed virtual network Gateway connection through Network resource
-// provider.
+// provider. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the name of the virtual network
 // gateway connection.
-func (client VirtualNetworkGatewayConnectionsClient) Delete(resourceGroupName string, virtualNetworkGatewayConnectionName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkGatewayConnectionName)
+func (client VirtualNetworkGatewayConnectionsClient) Delete(resourceGroupName string, virtualNetworkGatewayConnectionName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkGatewayConnectionName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -137,14 +143,14 @@ func (client VirtualNetworkGatewayConnectionsClient) Delete(resourceGroupName st
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualNetworkGatewayConnectionsClient) DeletePreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) DeletePreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":                   url.QueryEscape(resourceGroupName),
 		"subscriptionId":                      url.QueryEscape(client.SubscriptionID),
@@ -155,7 +161,7 @@ func (client VirtualNetworkGatewayConnectionsClient) DeletePreparer(resourceGrou
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -167,7 +173,9 @@ func (client VirtualNetworkGatewayConnectionsClient) DeletePreparer(resourceGrou
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewayConnectionsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -189,7 +197,7 @@ func (client VirtualNetworkGatewayConnectionsClient) DeleteResponder(resp *http.
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the name of the virtual network
 // gateway connection.
-func (client VirtualNetworkGatewayConnectionsClient) Get(resourceGroupName string, virtualNetworkGatewayConnectionName string) (result VirtualNetworkGatewayConnection, ae error) {
+func (client VirtualNetworkGatewayConnectionsClient) Get(resourceGroupName string, virtualNetworkGatewayConnectionName string) (result VirtualNetworkGatewayConnection, err error) {
 	req, err := client.GetPreparer(resourceGroupName, virtualNetworkGatewayConnectionName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Get", nil, "Failure preparing request")
@@ -203,7 +211,7 @@ func (client VirtualNetworkGatewayConnectionsClient) Get(resourceGroupName strin
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -233,7 +241,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetPreparer(resourceGroupNa
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewayConnectionsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -256,7 +264,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetResponder(resp *http.Res
 // resourceGroupName is the name of the resource group.
 // connectionSharedKeyName is the virtual network gateway connection shared
 // key name.
-func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(resourceGroupName string, connectionSharedKeyName string) (result ConnectionSharedKeyResult, ae error) {
+func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(resourceGroupName string, connectionSharedKeyName string) (result ConnectionSharedKeyResult, err error) {
 	req, err := client.GetSharedKeyPreparer(resourceGroupName, connectionSharedKeyName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "GetSharedKey", nil, "Failure preparing request")
@@ -270,7 +278,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(resourceGroupN
 
 	result, err = client.GetSharedKeyResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "GetSharedKey", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "GetSharedKey", resp, "Failure responding to request")
 	}
 
 	return
@@ -300,7 +308,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetSharedKeyPreparer(resour
 // GetSharedKeySender sends the GetSharedKey request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewayConnectionsClient) GetSharedKeySender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetSharedKeyResponder handles the response to the GetSharedKey request. The method always
@@ -320,7 +328,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetSharedKeyResponder(resp 
 // virtual network gateways connections created.
 //
 // resourceGroupName is the name of the resource group.
-func (client VirtualNetworkGatewayConnectionsClient) List(resourceGroupName string) (result VirtualNetworkGatewayConnectionListResult, ae error) {
+func (client VirtualNetworkGatewayConnectionsClient) List(resourceGroupName string) (result VirtualNetworkGatewayConnectionListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "List", nil, "Failure preparing request")
@@ -334,7 +342,7 @@ func (client VirtualNetworkGatewayConnectionsClient) List(resourceGroupName stri
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -363,7 +371,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ListPreparer(resourceGroupN
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewayConnectionsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -380,7 +388,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ListResponder(resp *http.Re
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client VirtualNetworkGatewayConnectionsClient) ListNextResults(lastResults VirtualNetworkGatewayConnectionListResult) (result VirtualNetworkGatewayConnectionListResult, ae error) {
+func (client VirtualNetworkGatewayConnectionsClient) ListNextResults(lastResults VirtualNetworkGatewayConnectionListResult) (result VirtualNetworkGatewayConnectionListResult, err error) {
 	req, err := lastResults.VirtualNetworkGatewayConnectionListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "List", nil, "Failure preparing next results request request")
@@ -397,7 +405,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ListNextResults(lastResults
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -406,35 +414,37 @@ func (client VirtualNetworkGatewayConnectionsClient) ListNextResults(lastResults
 // ResetSharedKey the VirtualNetworkGatewayConnectionResetSharedKey operation
 // resets the virtual network gateway connection shared key for passed
 // virtual network gateway connection in the specified resource group through
-// Network resource provider.
+// Network resource provider. This method may poll for completion. Polling
+// can be canceled by passing the cancel channel argument. The channel will
+// be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the virtual network gateway
 // connection reset shared key Name. parameters is parameters supplied to the
 // Begin Reset Virtual Network Gateway connection shared key operation
 // through Network resource provider.
-func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKey(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (result ConnectionResetSharedKey, ae error) {
-	req, err := client.ResetSharedKeyPreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKey(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.ResetSharedKeyPreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "ResetSharedKey", nil, "Failure preparing request")
 	}
 
 	resp, err := client.ResetSharedKeySender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "ResetSharedKey", resp, "Failure sending request")
 	}
 
 	result, err = client.ResetSharedKeyResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "ResetSharedKey", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "ResetSharedKey", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ResetSharedKeyPreparer prepares the ResetSharedKey request.
-func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyPreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyPreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":                   url.QueryEscape(resourceGroupName),
 		"subscriptionId":                      url.QueryEscape(client.SubscriptionID),
@@ -445,7 +455,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyPreparer(reso
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -458,54 +468,57 @@ func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyPreparer(reso
 // ResetSharedKeySender sends the ResetSharedKey request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeySender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // ResetSharedKeyResponder handles the response to the ResetSharedKey request. The method always
 // closes the http.Response Body.
-func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyResponder(resp *http.Response) (result ConnectionResetSharedKey, err error) {
+func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // SetSharedKey the Put VirtualNetworkGatewayConnectionSharedKey operation
 // sets the virtual network gateway connection shared key for passed virtual
 // network gateway connection in the specified resource group through Network
-// resource provider.
+// resource provider. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the virtual network gateway
 // connection name. parameters is parameters supplied to the Begin Set
 // Virtual Network Gateway conection Shared key operation throughNetwork
 // resource provider.
-func (client VirtualNetworkGatewayConnectionsClient) SetSharedKey(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (result ConnectionSharedKey, ae error) {
-	req, err := client.SetSharedKeyPreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client VirtualNetworkGatewayConnectionsClient) SetSharedKey(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.SetSharedKeyPreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "SetSharedKey", nil, "Failure preparing request")
 	}
 
 	resp, err := client.SetSharedKeySender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "SetSharedKey", resp, "Failure sending request")
 	}
 
 	result, err = client.SetSharedKeyResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "SetSharedKey", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "SetSharedKey", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // SetSharedKeyPreparer prepares the SetSharedKey request.
-func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyPreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyPreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":                   url.QueryEscape(resourceGroupName),
 		"subscriptionId":                      url.QueryEscape(client.SubscriptionID),
@@ -516,7 +529,7 @@ func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyPreparer(resour
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -529,18 +542,19 @@ func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyPreparer(resour
 // SetSharedKeySender sends the SetSharedKey request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeySender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // SetSharedKeyResponder handles the response to the SetSharedKey request. The method always
 // closes the http.Response Body.
-func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyResponder(resp *http.Response) (result ConnectionSharedKey, err error) {
+func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworkgateways.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworkgateways.go
@@ -48,34 +48,36 @@ func NewVirtualNetworkGatewaysClientWithBaseURI(baseURI string, subscriptionID s
 
 // CreateOrUpdate the Put VirtualNetworkGateway operation creates/updates a
 // virtual network gateway in the specified resource group through Network
-// resource provider.
+// resource provider. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayName is the name of the virtual network gateway.
 // parameters is parameters supplied to the Begin Create or update Virtual
 // Network Gateway operation through Network resource provider.
-func (client VirtualNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (result VirtualNetworkGateway, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client VirtualNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkGatewayName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*http.Request, error) {
+func (client VirtualNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":         url.QueryEscape(resourceGroupName),
 		"subscriptionId":            url.QueryEscape(client.SubscriptionID),
@@ -86,7 +88,7 @@ func (client VirtualNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupN
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,29 +101,33 @@ func (client VirtualNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupN
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewaysClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client VirtualNetworkGatewaysClient) CreateOrUpdateResponder(resp *http.Response) (result VirtualNetworkGateway, err error) {
+func (client VirtualNetworkGatewaysClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the Delete VirtualNetworkGateway operation deletes the specifed
-// virtual network Gateway through Network resource provider.
+// virtual network Gateway through Network resource provider. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayName is the name of the virtual network gateway.
-func (client VirtualNetworkGatewaysClient) Delete(resourceGroupName string, virtualNetworkGatewayName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkGatewayName)
+func (client VirtualNetworkGatewaysClient) Delete(resourceGroupName string, virtualNetworkGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Delete", nil, "Failure preparing request")
 	}
@@ -134,14 +140,14 @@ func (client VirtualNetworkGatewaysClient) Delete(resourceGroupName string, virt
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualNetworkGatewaysClient) DeletePreparer(resourceGroupName string, virtualNetworkGatewayName string) (*http.Request, error) {
+func (client VirtualNetworkGatewaysClient) DeletePreparer(resourceGroupName string, virtualNetworkGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":         url.QueryEscape(resourceGroupName),
 		"subscriptionId":            url.QueryEscape(client.SubscriptionID),
@@ -152,7 +158,7 @@ func (client VirtualNetworkGatewaysClient) DeletePreparer(resourceGroupName stri
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -164,7 +170,9 @@ func (client VirtualNetworkGatewaysClient) DeletePreparer(resourceGroupName stri
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewaysClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -187,7 +195,7 @@ func (client VirtualNetworkGatewaysClient) DeleteResponder(resp *http.Response) 
 // virtualNetworkGatewayName is the name of the virtual network gateway.
 // parameters is parameters supplied to the Begin Generating  Virtual Network
 // Gateway Vpn client package operation through Network resource provider.
-func (client VirtualNetworkGatewaysClient) Generatevpnclientpackage(resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (result String, ae error) {
+func (client VirtualNetworkGatewaysClient) Generatevpnclientpackage(resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (result String, err error) {
 	req, err := client.GeneratevpnclientpackagePreparer(resourceGroupName, virtualNetworkGatewayName, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Generatevpnclientpackage", nil, "Failure preparing request")
@@ -201,7 +209,7 @@ func (client VirtualNetworkGatewaysClient) Generatevpnclientpackage(resourceGrou
 
 	result, err = client.GeneratevpnclientpackageResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Generatevpnclientpackage", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Generatevpnclientpackage", resp, "Failure responding to request")
 	}
 
 	return
@@ -232,7 +240,7 @@ func (client VirtualNetworkGatewaysClient) GeneratevpnclientpackagePreparer(reso
 // GeneratevpnclientpackageSender sends the Generatevpnclientpackage request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewaysClient) GeneratevpnclientpackageSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GeneratevpnclientpackageResponder handles the response to the Generatevpnclientpackage request. The method always
@@ -253,7 +261,7 @@ func (client VirtualNetworkGatewaysClient) GeneratevpnclientpackageResponder(res
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayName is the name of the virtual network gateway.
-func (client VirtualNetworkGatewaysClient) Get(resourceGroupName string, virtualNetworkGatewayName string) (result VirtualNetworkGateway, ae error) {
+func (client VirtualNetworkGatewaysClient) Get(resourceGroupName string, virtualNetworkGatewayName string) (result VirtualNetworkGateway, err error) {
 	req, err := client.GetPreparer(resourceGroupName, virtualNetworkGatewayName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Get", nil, "Failure preparing request")
@@ -267,7 +275,7 @@ func (client VirtualNetworkGatewaysClient) Get(resourceGroupName string, virtual
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -297,7 +305,7 @@ func (client VirtualNetworkGatewaysClient) GetPreparer(resourceGroupName string,
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewaysClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -317,7 +325,7 @@ func (client VirtualNetworkGatewaysClient) GetResponder(resp *http.Response) (re
 // network gateways stored.
 //
 // resourceGroupName is the name of the resource group.
-func (client VirtualNetworkGatewaysClient) List(resourceGroupName string) (result VirtualNetworkGatewayListResult, ae error) {
+func (client VirtualNetworkGatewaysClient) List(resourceGroupName string) (result VirtualNetworkGatewayListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "List", nil, "Failure preparing request")
@@ -331,7 +339,7 @@ func (client VirtualNetworkGatewaysClient) List(resourceGroupName string) (resul
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -360,7 +368,7 @@ func (client VirtualNetworkGatewaysClient) ListPreparer(resourceGroupName string
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewaysClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -377,7 +385,7 @@ func (client VirtualNetworkGatewaysClient) ListResponder(resp *http.Response) (r
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client VirtualNetworkGatewaysClient) ListNextResults(lastResults VirtualNetworkGatewayListResult) (result VirtualNetworkGatewayListResult, ae error) {
+func (client VirtualNetworkGatewaysClient) ListNextResults(lastResults VirtualNetworkGatewayListResult) (result VirtualNetworkGatewayListResult, err error) {
 	req, err := lastResults.VirtualNetworkGatewayListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "List", nil, "Failure preparing next results request request")
@@ -394,7 +402,7 @@ func (client VirtualNetworkGatewaysClient) ListNextResults(lastResults VirtualNe
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -402,34 +410,36 @@ func (client VirtualNetworkGatewaysClient) ListNextResults(lastResults VirtualNe
 
 // Reset the Reset VirtualNetworkGateway operation resets the primary of the
 // virtual network gateway in the specified resource group through Network
-// resource provider.
+// resource provider. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayName is the name of the virtual network gateway.
 // parameters is parameters supplied to the Begin Reset Virtual Network
 // Gateway operation through Network resource provider.
-func (client VirtualNetworkGatewaysClient) Reset(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (result VirtualNetworkGateway, ae error) {
-	req, err := client.ResetPreparer(resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client VirtualNetworkGatewaysClient) Reset(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.ResetPreparer(resourceGroupName, virtualNetworkGatewayName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Reset", nil, "Failure preparing request")
 	}
 
 	resp, err := client.ResetSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Reset", resp, "Failure sending request")
 	}
 
 	result, err = client.ResetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Reset", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Reset", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ResetPreparer prepares the Reset request.
-func (client VirtualNetworkGatewaysClient) ResetPreparer(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*http.Request, error) {
+func (client VirtualNetworkGatewaysClient) ResetPreparer(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":         url.QueryEscape(resourceGroupName),
 		"subscriptionId":            url.QueryEscape(client.SubscriptionID),
@@ -440,7 +450,7 @@ func (client VirtualNetworkGatewaysClient) ResetPreparer(resourceGroupName strin
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -453,18 +463,19 @@ func (client VirtualNetworkGatewaysClient) ResetPreparer(resourceGroupName strin
 // ResetSender sends the Reset request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworkGatewaysClient) ResetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // ResetResponder handles the response to the Reset request. The method always
 // closes the http.Response Body.
-func (client VirtualNetworkGatewaysClient) ResetResponder(resp *http.Response) (result VirtualNetworkGateway, err error) {
+func (client VirtualNetworkGatewaysClient) ResetResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworks.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworks.go
@@ -47,33 +47,36 @@ func NewVirtualNetworksClientWithBaseURI(baseURI string, subscriptionID string) 
 }
 
 // CreateOrUpdate the Put VirtualNetwork operation creates/updates a virtual
-// network in the specified resource group.
+// network in the specified resource group. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network. parameters is parameters supplied to the
 // create/update Virtual Network operation
-func (client VirtualNetworksClient) CreateOrUpdate(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (result VirtualNetwork, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkName, parameters)
+func (client VirtualNetworksClient) CreateOrUpdate(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualNetworksClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (*http.Request, error) {
+func (client VirtualNetworksClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":  url.QueryEscape(resourceGroupName),
 		"subscriptionId":     url.QueryEscape(client.SubscriptionID),
@@ -84,7 +87,7 @@ func (client VirtualNetworksClient) CreateOrUpdatePreparer(resourceGroupName str
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -97,29 +100,32 @@ func (client VirtualNetworksClient) CreateOrUpdatePreparer(resourceGroupName str
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworksClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client VirtualNetworksClient) CreateOrUpdateResponder(resp *http.Response) (result VirtualNetwork, err error) {
+func (client VirtualNetworksClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete the Delete VirtualNetwork operation deletes the specifed virtual
-// network
+// network This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network.
-func (client VirtualNetworksClient) Delete(resourceGroupName string, virtualNetworkName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkName)
+func (client VirtualNetworksClient) Delete(resourceGroupName string, virtualNetworkName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Delete", nil, "Failure preparing request")
 	}
@@ -132,14 +138,14 @@ func (client VirtualNetworksClient) Delete(resourceGroupName string, virtualNetw
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualNetworksClient) DeletePreparer(resourceGroupName string, virtualNetworkName string) (*http.Request, error) {
+func (client VirtualNetworksClient) DeletePreparer(resourceGroupName string, virtualNetworkName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":  url.QueryEscape(resourceGroupName),
 		"subscriptionId":     url.QueryEscape(client.SubscriptionID),
@@ -150,7 +156,7 @@ func (client VirtualNetworksClient) DeletePreparer(resourceGroupName string, vir
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -162,7 +168,9 @@ func (client VirtualNetworksClient) DeletePreparer(resourceGroupName string, vir
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworksClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -182,7 +190,7 @@ func (client VirtualNetworksClient) DeleteResponder(resp *http.Response) (result
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network. expand is expand references resources.
-func (client VirtualNetworksClient) Get(resourceGroupName string, virtualNetworkName string, expand string) (result VirtualNetwork, ae error) {
+func (client VirtualNetworksClient) Get(resourceGroupName string, virtualNetworkName string, expand string) (result VirtualNetwork, err error) {
 	req, err := client.GetPreparer(resourceGroupName, virtualNetworkName, expand)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Get", nil, "Failure preparing request")
@@ -196,7 +204,7 @@ func (client VirtualNetworksClient) Get(resourceGroupName string, virtualNetwork
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -229,7 +237,7 @@ func (client VirtualNetworksClient) GetPreparer(resourceGroupName string, virtua
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworksClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -249,7 +257,7 @@ func (client VirtualNetworksClient) GetResponder(resp *http.Response) (result Vi
 // group
 //
 // resourceGroupName is the name of the resource group.
-func (client VirtualNetworksClient) List(resourceGroupName string) (result VirtualNetworkListResult, ae error) {
+func (client VirtualNetworksClient) List(resourceGroupName string) (result VirtualNetworkListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "List", nil, "Failure preparing request")
@@ -263,7 +271,7 @@ func (client VirtualNetworksClient) List(resourceGroupName string) (result Virtu
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -292,7 +300,7 @@ func (client VirtualNetworksClient) ListPreparer(resourceGroupName string) (*htt
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworksClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -309,7 +317,7 @@ func (client VirtualNetworksClient) ListResponder(resp *http.Response) (result V
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client VirtualNetworksClient) ListNextResults(lastResults VirtualNetworkListResult) (result VirtualNetworkListResult, ae error) {
+func (client VirtualNetworksClient) ListNextResults(lastResults VirtualNetworkListResult) (result VirtualNetworkListResult, err error) {
 	req, err := lastResults.VirtualNetworkListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "List", nil, "Failure preparing next results request request")
@@ -326,7 +334,7 @@ func (client VirtualNetworksClient) ListNextResults(lastResults VirtualNetworkLi
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -334,7 +342,7 @@ func (client VirtualNetworksClient) ListNextResults(lastResults VirtualNetworkLi
 
 // ListAll the list VirtualNetwork returns all Virtual Networks in a
 // subscription
-func (client VirtualNetworksClient) ListAll() (result VirtualNetworkListResult, ae error) {
+func (client VirtualNetworksClient) ListAll() (result VirtualNetworkListResult, err error) {
 	req, err := client.ListAllPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "ListAll", nil, "Failure preparing request")
@@ -348,7 +356,7 @@ func (client VirtualNetworksClient) ListAll() (result VirtualNetworkListResult, 
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "ListAll", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "ListAll", resp, "Failure responding to request")
 	}
 
 	return
@@ -376,7 +384,7 @@ func (client VirtualNetworksClient) ListAllPreparer() (*http.Request, error) {
 // ListAllSender sends the ListAll request. The method will close the
 // http.Response Body if it receives an error.
 func (client VirtualNetworksClient) ListAllSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListAllResponder handles the response to the ListAll request. The method always
@@ -393,7 +401,7 @@ func (client VirtualNetworksClient) ListAllResponder(resp *http.Response) (resul
 }
 
 // ListAllNextResults retrieves the next set of results, if any.
-func (client VirtualNetworksClient) ListAllNextResults(lastResults VirtualNetworkListResult) (result VirtualNetworkListResult, ae error) {
+func (client VirtualNetworksClient) ListAllNextResults(lastResults VirtualNetworkListResult) (result VirtualNetworkListResult, err error) {
 	req, err := lastResults.VirtualNetworkListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "ListAll", nil, "Failure preparing next results request request")
@@ -410,7 +418,7 @@ func (client VirtualNetworksClient) ListAllNextResults(lastResults VirtualNetwor
 
 	result, err = client.ListAllResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "ListAll", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "ListAll", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/client.go
@@ -63,7 +63,7 @@ func NewWithBaseURI(baseURI string, subscriptionID string) ManagementClient {
 // insensitive. resourceProviderNamespace is resource identity.
 // parentResourcePath is resource identity. resourceType is resource
 // identity. resourceName is resource identity.
-func (client ManagementClient) CheckExistence(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result autorest.Response, ae error) {
+func (client ManagementClient) CheckExistence(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result autorest.Response, err error) {
 	req, err := client.CheckExistencePreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "CheckExistence", nil, "Failure preparing request")
@@ -77,7 +77,7 @@ func (client ManagementClient) CheckExistence(resourceGroupName string, resource
 
 	result, err = client.CheckExistenceResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ManagementClient", "CheckExistence", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ManagementClient", "CheckExistence", resp, "Failure responding to request")
 	}
 
 	return
@@ -110,7 +110,7 @@ func (client ManagementClient) CheckExistencePreparer(resourceGroupName string, 
 // CheckExistenceSender sends the CheckExistence request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) CheckExistenceSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CheckExistenceResponder handles the response to the CheckExistence request. The method always
@@ -132,7 +132,7 @@ func (client ManagementClient) CheckExistenceResponder(resp *http.Response) (res
 // parentResourcePath is resource identity. resourceType is resource
 // identity. resourceName is resource identity. parameters is create or
 // update resource parameters.
-func (client ManagementClient) CreateOrUpdate(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string, parameters GenericResource) (result GenericResource, ae error) {
+func (client ManagementClient) CreateOrUpdate(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string, parameters GenericResource) (result GenericResource, err error) {
 	req, err := client.CreateOrUpdatePreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "CreateOrUpdate", nil, "Failure preparing request")
@@ -146,7 +146,7 @@ func (client ManagementClient) CreateOrUpdate(resourceGroupName string, resource
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ManagementClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ManagementClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
@@ -180,7 +180,7 @@ func (client ManagementClient) CreateOrUpdatePreparer(resourceGroupName string, 
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -202,7 +202,7 @@ func (client ManagementClient) CreateOrUpdateResponder(resp *http.Response) (res
 // insensitive. resourceProviderNamespace is resource identity.
 // parentResourcePath is resource identity. resourceType is resource
 // identity. resourceName is resource identity.
-func (client ManagementClient) Delete(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result autorest.Response, ae error) {
+func (client ManagementClient) Delete(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result autorest.Response, err error) {
 	req, err := client.DeletePreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "Delete", nil, "Failure preparing request")
@@ -216,7 +216,7 @@ func (client ManagementClient) Delete(resourceGroupName string, resourceProvider
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ManagementClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ManagementClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
@@ -249,7 +249,7 @@ func (client ManagementClient) DeletePreparer(resourceGroupName string, resource
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -270,7 +270,7 @@ func (client ManagementClient) DeleteResponder(resp *http.Response) (result auto
 // insensitive. resourceProviderNamespace is resource identity.
 // parentResourcePath is resource identity. resourceType is resource
 // identity. resourceName is resource identity.
-func (client ManagementClient) Get(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result GenericResource, ae error) {
+func (client ManagementClient) Get(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result GenericResource, err error) {
 	req, err := client.GetPreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "Get", nil, "Failure preparing request")
@@ -284,7 +284,7 @@ func (client ManagementClient) Get(resourceGroupName string, resourceProviderNam
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ManagementClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ManagementClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -317,7 +317,7 @@ func (client ManagementClient) GetPreparer(resourceGroupName string, resourcePro
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -337,7 +337,7 @@ func (client ManagementClient) GetResponder(resp *http.Response) (result Generic
 //
 // filter is the filter to apply on the operation. top is query parameters. If
 // null is passed returns all resource groups.
-func (client ManagementClient) List(filter string, top *int) (result ResourceListResult, ae error) {
+func (client ManagementClient) List(filter string, top *int32) (result ResourceListResult, err error) {
 	req, err := client.ListPreparer(filter, top)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "List", nil, "Failure preparing request")
@@ -351,14 +351,14 @@ func (client ManagementClient) List(filter string, top *int) (result ResourceLis
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ManagementClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ManagementClient", "List", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListPreparer prepares the List request.
-func (client ManagementClient) ListPreparer(filter string, top *int) (*http.Request, error) {
+func (client ManagementClient) ListPreparer(filter string, top *int32) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"subscriptionId": url.QueryEscape(client.SubscriptionID),
 	}
@@ -385,7 +385,7 @@ func (client ManagementClient) ListPreparer(filter string, top *int) (*http.Requ
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -402,7 +402,7 @@ func (client ManagementClient) ListResponder(resp *http.Response) (result Resour
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ManagementClient) ListNextResults(lastResults ResourceListResult) (result ResourceListResult, ae error) {
+func (client ManagementClient) ListNextResults(lastResults ResourceListResult) (result ResourceListResult, err error) {
 	req, err := lastResults.ResourceListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "List", nil, "Failure preparing next results request request")
@@ -419,19 +419,22 @@ func (client ManagementClient) ListNextResults(lastResults ResourceListResult) (
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ManagementClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/ManagementClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
 }
 
 // MoveResources begin moving resources.To determine whether the operation has
-// finished processing the request, call GetLongRunningOperationStatus.
+// finished processing the request, call GetLongRunningOperationStatus. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // sourceResourceGroupName is source resource group name. parameters is move
 // resources' parameters.
-func (client ManagementClient) MoveResources(sourceResourceGroupName string, parameters MoveInfo) (result autorest.Response, ae error) {
-	req, err := client.MoveResourcesPreparer(sourceResourceGroupName, parameters)
+func (client ManagementClient) MoveResources(sourceResourceGroupName string, parameters MoveInfo, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.MoveResourcesPreparer(sourceResourceGroupName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "MoveResources", nil, "Failure preparing request")
 	}
@@ -444,14 +447,14 @@ func (client ManagementClient) MoveResources(sourceResourceGroupName string, par
 
 	result, err = client.MoveResourcesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ManagementClient", "MoveResources", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ManagementClient", "MoveResources", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // MoveResourcesPreparer prepares the MoveResources request.
-func (client ManagementClient) MoveResourcesPreparer(sourceResourceGroupName string, parameters MoveInfo) (*http.Request, error) {
+func (client ManagementClient) MoveResourcesPreparer(sourceResourceGroupName string, parameters MoveInfo, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"sourceResourceGroupName": url.QueryEscape(sourceResourceGroupName),
 		"subscriptionId":          url.QueryEscape(client.SubscriptionID),
@@ -461,7 +464,7 @@ func (client ManagementClient) MoveResourcesPreparer(sourceResourceGroupName str
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -474,7 +477,9 @@ func (client ManagementClient) MoveResourcesPreparer(sourceResourceGroupName str
 // MoveResourcesSender sends the MoveResources request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) MoveResourcesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // MoveResourcesResponder handles the response to the MoveResources request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/deploymentoperations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/deploymentoperations.go
@@ -48,7 +48,7 @@ func NewDeploymentOperationsClientWithBaseURI(baseURI string, subscriptionID str
 // resourceGroupName is the name of the resource group. The name is case
 // insensitive. deploymentName is the name of the deployment. operationID is
 // operation Id.
-func (client DeploymentOperationsClient) Get(resourceGroupName string, deploymentName string, operationID string) (result DeploymentOperation, ae error) {
+func (client DeploymentOperationsClient) Get(resourceGroupName string, deploymentName string, operationID string) (result DeploymentOperation, err error) {
 	req, err := client.GetPreparer(resourceGroupName, deploymentName, operationID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "Get", nil, "Failure preparing request")
@@ -62,7 +62,7 @@ func (client DeploymentOperationsClient) Get(resourceGroupName string, deploymen
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -93,7 +93,7 @@ func (client DeploymentOperationsClient) GetPreparer(resourceGroupName string, d
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentOperationsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -114,7 +114,7 @@ func (client DeploymentOperationsClient) GetResponder(resp *http.Response) (resu
 // resourceGroupName is the name of the resource group. The name is case
 // insensitive. deploymentName is the name of the deployment. top is query
 // parameters.
-func (client DeploymentOperationsClient) List(resourceGroupName string, deploymentName string, top *int) (result DeploymentOperationsListResult, ae error) {
+func (client DeploymentOperationsClient) List(resourceGroupName string, deploymentName string, top *int32) (result DeploymentOperationsListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName, deploymentName, top)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "List", nil, "Failure preparing request")
@@ -128,14 +128,14 @@ func (client DeploymentOperationsClient) List(resourceGroupName string, deployme
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListPreparer prepares the List request.
-func (client DeploymentOperationsClient) ListPreparer(resourceGroupName string, deploymentName string, top *int) (*http.Request, error) {
+func (client DeploymentOperationsClient) ListPreparer(resourceGroupName string, deploymentName string, top *int32) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"deploymentName":    url.QueryEscape(deploymentName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -161,7 +161,7 @@ func (client DeploymentOperationsClient) ListPreparer(resourceGroupName string, 
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentOperationsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -178,7 +178,7 @@ func (client DeploymentOperationsClient) ListResponder(resp *http.Response) (res
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client DeploymentOperationsClient) ListNextResults(lastResults DeploymentOperationsListResult) (result DeploymentOperationsListResult, ae error) {
+func (client DeploymentOperationsClient) ListNextResults(lastResults DeploymentOperationsListResult) (result DeploymentOperationsListResult, err error) {
 	req, err := lastResults.DeploymentOperationsListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "List", nil, "Failure preparing next results request request")
@@ -195,7 +195,7 @@ func (client DeploymentOperationsClient) ListNextResults(lastResults DeploymentO
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/deployments.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/deployments.go
@@ -46,7 +46,7 @@ func NewDeploymentsClientWithBaseURI(baseURI string, subscriptionID string) Depl
 //
 // resourceGroupName is the name of the resource group. The name is case
 // insensitive. deploymentName is the name of the deployment.
-func (client DeploymentsClient) Cancel(resourceGroupName string, deploymentName string) (result autorest.Response, ae error) {
+func (client DeploymentsClient) Cancel(resourceGroupName string, deploymentName string) (result autorest.Response, err error) {
 	req, err := client.CancelPreparer(resourceGroupName, deploymentName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Cancel", nil, "Failure preparing request")
@@ -60,7 +60,7 @@ func (client DeploymentsClient) Cancel(resourceGroupName string, deploymentName 
 
 	result, err = client.CancelResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Cancel", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Cancel", resp, "Failure responding to request")
 	}
 
 	return
@@ -90,7 +90,7 @@ func (client DeploymentsClient) CancelPreparer(resourceGroupName string, deploym
 // CancelSender sends the Cancel request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentsClient) CancelSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CancelResponder handles the response to the Cancel request. The method always
@@ -109,7 +109,7 @@ func (client DeploymentsClient) CancelResponder(resp *http.Response) (result aut
 //
 // resourceGroupName is the name of the resource group to check. The name is
 // case insensitive. deploymentName is the name of the deployment.
-func (client DeploymentsClient) CheckExistence(resourceGroupName string, deploymentName string) (result autorest.Response, ae error) {
+func (client DeploymentsClient) CheckExistence(resourceGroupName string, deploymentName string) (result autorest.Response, err error) {
 	req, err := client.CheckExistencePreparer(resourceGroupName, deploymentName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CheckExistence", nil, "Failure preparing request")
@@ -123,7 +123,7 @@ func (client DeploymentsClient) CheckExistence(resourceGroupName string, deploym
 
 	result, err = client.CheckExistenceResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CheckExistence", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CheckExistence", resp, "Failure responding to request")
 	}
 
 	return
@@ -153,7 +153,7 @@ func (client DeploymentsClient) CheckExistencePreparer(resourceGroupName string,
 // CheckExistenceSender sends the CheckExistence request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentsClient) CheckExistenceSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CheckExistenceResponder handles the response to the CheckExistence request. The method always
@@ -168,33 +168,36 @@ func (client DeploymentsClient) CheckExistenceResponder(resp *http.Response) (re
 	return
 }
 
-// CreateOrUpdate create a named template deployment using a template.
+// CreateOrUpdate create a named template deployment using a template. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. The name is case
 // insensitive. deploymentName is the name of the deployment. parameters is
 // additional parameters supplied to the operation.
-func (client DeploymentsClient) CreateOrUpdate(resourceGroupName string, deploymentName string, parameters Deployment) (result DeploymentExtended, ae error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, deploymentName, parameters)
+func (client DeploymentsClient) CreateOrUpdate(resourceGroupName string, deploymentName string, parameters Deployment, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, deploymentName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CreateOrUpdate", resp, "Failure sending request")
 	}
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client DeploymentsClient) CreateOrUpdatePreparer(resourceGroupName string, deploymentName string, parameters Deployment) (*http.Request, error) {
+func (client DeploymentsClient) CreateOrUpdatePreparer(resourceGroupName string, deploymentName string, parameters Deployment, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"deploymentName":    url.QueryEscape(deploymentName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -205,7 +208,7 @@ func (client DeploymentsClient) CreateOrUpdatePreparer(resourceGroupName string,
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -218,29 +221,33 @@ func (client DeploymentsClient) CreateOrUpdatePreparer(resourceGroupName string,
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
 // closes the http.Response Body.
-func (client DeploymentsClient) CreateOrUpdateResponder(resp *http.Response) (result DeploymentExtended, err error) {
+func (client DeploymentsClient) CreateOrUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
-		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
+	result.Response = resp
 	return
 }
 
 // Delete begin deleting deployment.To determine whether the operation has
-// finished processing the request, call GetLongRunningOperationStatus.
+// finished processing the request, call GetLongRunningOperationStatus. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. The name is case
 // insensitive. deploymentName is the name of the deployment to be deleted.
-func (client DeploymentsClient) Delete(resourceGroupName string, deploymentName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName, deploymentName)
+func (client DeploymentsClient) Delete(resourceGroupName string, deploymentName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, deploymentName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -253,14 +260,14 @@ func (client DeploymentsClient) Delete(resourceGroupName string, deploymentName 
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client DeploymentsClient) DeletePreparer(resourceGroupName string, deploymentName string) (*http.Request, error) {
+func (client DeploymentsClient) DeletePreparer(resourceGroupName string, deploymentName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"deploymentName":    url.QueryEscape(deploymentName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -271,7 +278,7 @@ func (client DeploymentsClient) DeletePreparer(resourceGroupName string, deploym
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -283,7 +290,9 @@ func (client DeploymentsClient) DeletePreparer(resourceGroupName string, deploym
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -302,7 +311,7 @@ func (client DeploymentsClient) DeleteResponder(resp *http.Response) (result aut
 //
 // resourceGroupName is the name of the resource group to get. The name is
 // case insensitive. deploymentName is the name of the deployment.
-func (client DeploymentsClient) Get(resourceGroupName string, deploymentName string) (result DeploymentExtended, ae error) {
+func (client DeploymentsClient) Get(resourceGroupName string, deploymentName string) (result DeploymentExtended, err error) {
 	req, err := client.GetPreparer(resourceGroupName, deploymentName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Get", nil, "Failure preparing request")
@@ -316,7 +325,7 @@ func (client DeploymentsClient) Get(resourceGroupName string, deploymentName str
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -346,7 +355,7 @@ func (client DeploymentsClient) GetPreparer(resourceGroupName string, deployment
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -367,7 +376,7 @@ func (client DeploymentsClient) GetResponder(resp *http.Response) (result Deploy
 // resourceGroupName is the name of the resource group to filter by. The name
 // is case insensitive. filter is the filter to apply on the operation. top
 // is query parameters. If null is passed returns all deployments.
-func (client DeploymentsClient) List(resourceGroupName string, filter string, top *int) (result DeploymentListResult, ae error) {
+func (client DeploymentsClient) List(resourceGroupName string, filter string, top *int32) (result DeploymentListResult, err error) {
 	req, err := client.ListPreparer(resourceGroupName, filter, top)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "List", nil, "Failure preparing request")
@@ -381,14 +390,14 @@ func (client DeploymentsClient) List(resourceGroupName string, filter string, to
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListPreparer prepares the List request.
-func (client DeploymentsClient) ListPreparer(resourceGroupName string, filter string, top *int) (*http.Request, error) {
+func (client DeploymentsClient) ListPreparer(resourceGroupName string, filter string, top *int32) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -416,7 +425,7 @@ func (client DeploymentsClient) ListPreparer(resourceGroupName string, filter st
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -433,7 +442,7 @@ func (client DeploymentsClient) ListResponder(resp *http.Response) (result Deplo
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client DeploymentsClient) ListNextResults(lastResults DeploymentListResult) (result DeploymentListResult, ae error) {
+func (client DeploymentsClient) ListNextResults(lastResults DeploymentListResult) (result DeploymentListResult, err error) {
 	req, err := lastResults.DeploymentListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "List", nil, "Failure preparing next results request request")
@@ -450,7 +459,7 @@ func (client DeploymentsClient) ListNextResults(lastResults DeploymentListResult
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -461,7 +470,7 @@ func (client DeploymentsClient) ListNextResults(lastResults DeploymentListResult
 // resourceGroupName is the name of the resource group. The name is case
 // insensitive. deploymentName is the name of the deployment. parameters is
 // deployment to validate.
-func (client DeploymentsClient) Validate(resourceGroupName string, deploymentName string, parameters Deployment) (result DeploymentValidateResult, ae error) {
+func (client DeploymentsClient) Validate(resourceGroupName string, deploymentName string, parameters Deployment) (result DeploymentValidateResult, err error) {
 	req, err := client.ValidatePreparer(resourceGroupName, deploymentName, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Validate", nil, "Failure preparing request")
@@ -475,7 +484,7 @@ func (client DeploymentsClient) Validate(resourceGroupName string, deploymentNam
 
 	result, err = client.ValidateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Validate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Validate", resp, "Failure responding to request")
 	}
 
 	return
@@ -506,7 +515,7 @@ func (client DeploymentsClient) ValidatePreparer(resourceGroupName string, deplo
 // ValidateSender sends the Validate request. The method will close the
 // http.Response Body if it receives an error.
 func (client DeploymentsClient) ValidateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ValidateResponder handles the response to the Validate request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/groups.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/groups.go
@@ -44,7 +44,7 @@ func NewGroupsClientWithBaseURI(baseURI string, subscriptionID string) GroupsCli
 //
 // resourceGroupName is the name of the resource group to check. The name is
 // case insensitive.
-func (client GroupsClient) CheckExistence(resourceGroupName string) (result autorest.Response, ae error) {
+func (client GroupsClient) CheckExistence(resourceGroupName string) (result autorest.Response, err error) {
 	req, err := client.CheckExistencePreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "CheckExistence", nil, "Failure preparing request")
@@ -58,7 +58,7 @@ func (client GroupsClient) CheckExistence(resourceGroupName string) (result auto
 
 	result, err = client.CheckExistenceResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "CheckExistence", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "CheckExistence", resp, "Failure responding to request")
 	}
 
 	return
@@ -87,7 +87,7 @@ func (client GroupsClient) CheckExistencePreparer(resourceGroupName string) (*ht
 // CheckExistenceSender sends the CheckExistence request. The method will close the
 // http.Response Body if it receives an error.
 func (client GroupsClient) CheckExistenceSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CheckExistenceResponder handles the response to the CheckExistence request. The method always
@@ -107,7 +107,7 @@ func (client GroupsClient) CheckExistenceResponder(resp *http.Response) (result 
 // resourceGroupName is the name of the resource group to be created or
 // updated. parameters is parameters supplied to the create or update
 // resource group service operation.
-func (client GroupsClient) CreateOrUpdate(resourceGroupName string, parameters ResourceGroup) (result ResourceGroup, ae error) {
+func (client GroupsClient) CreateOrUpdate(resourceGroupName string, parameters ResourceGroup) (result ResourceGroup, err error) {
 	req, err := client.CreateOrUpdatePreparer(resourceGroupName, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "CreateOrUpdate", nil, "Failure preparing request")
@@ -121,7 +121,7 @@ func (client GroupsClient) CreateOrUpdate(resourceGroupName string, parameters R
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
@@ -151,7 +151,7 @@ func (client GroupsClient) CreateOrUpdatePreparer(resourceGroupName string, para
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client GroupsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -168,12 +168,15 @@ func (client GroupsClient) CreateOrUpdateResponder(resp *http.Response) (result 
 }
 
 // Delete begin deleting resource group.To determine whether the operation has
-// finished processing the request, call GetLongRunningOperationStatus.
+// finished processing the request, call GetLongRunningOperationStatus. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group to be deleted. The name
 // is case insensitive.
-func (client GroupsClient) Delete(resourceGroupName string) (result autorest.Response, ae error) {
-	req, err := client.DeletePreparer(resourceGroupName)
+func (client GroupsClient) Delete(resourceGroupName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -186,14 +189,14 @@ func (client GroupsClient) Delete(resourceGroupName string) (result autorest.Res
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // DeletePreparer prepares the Delete request.
-func (client GroupsClient) DeletePreparer(resourceGroupName string) (*http.Request, error) {
+func (client GroupsClient) DeletePreparer(resourceGroupName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -203,7 +206,7 @@ func (client GroupsClient) DeletePreparer(resourceGroupName string) (*http.Reque
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -215,7 +218,9 @@ func (client GroupsClient) DeletePreparer(resourceGroupName string) (*http.Reque
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client GroupsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -234,7 +239,7 @@ func (client GroupsClient) DeleteResponder(resp *http.Response) (result autorest
 //
 // resourceGroupName is the name of the resource group to get. The name is
 // case insensitive.
-func (client GroupsClient) Get(resourceGroupName string) (result ResourceGroup, ae error) {
+func (client GroupsClient) Get(resourceGroupName string) (result ResourceGroup, err error) {
 	req, err := client.GetPreparer(resourceGroupName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "Get", nil, "Failure preparing request")
@@ -248,7 +253,7 @@ func (client GroupsClient) Get(resourceGroupName string) (result ResourceGroup, 
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -277,7 +282,7 @@ func (client GroupsClient) GetPreparer(resourceGroupName string) (*http.Request,
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client GroupsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -297,7 +302,7 @@ func (client GroupsClient) GetResponder(resp *http.Response) (result ResourceGro
 //
 // filter is the filter to apply on the operation. top is query parameters. If
 // null is passed returns all resource groups.
-func (client GroupsClient) List(filter string, top *int) (result ResourceGroupListResult, ae error) {
+func (client GroupsClient) List(filter string, top *int32) (result ResourceGroupListResult, err error) {
 	req, err := client.ListPreparer(filter, top)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "List", nil, "Failure preparing request")
@@ -311,14 +316,14 @@ func (client GroupsClient) List(filter string, top *int) (result ResourceGroupLi
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListPreparer prepares the List request.
-func (client GroupsClient) ListPreparer(filter string, top *int) (*http.Request, error) {
+func (client GroupsClient) ListPreparer(filter string, top *int32) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"subscriptionId": url.QueryEscape(client.SubscriptionID),
 	}
@@ -345,7 +350,7 @@ func (client GroupsClient) ListPreparer(filter string, top *int) (*http.Request,
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client GroupsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -362,7 +367,7 @@ func (client GroupsClient) ListResponder(resp *http.Response) (result ResourceGr
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client GroupsClient) ListNextResults(lastResults ResourceGroupListResult) (result ResourceGroupListResult, ae error) {
+func (client GroupsClient) ListNextResults(lastResults ResourceGroupListResult) (result ResourceGroupListResult, err error) {
 	req, err := lastResults.ResourceGroupListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "List", nil, "Failure preparing next results request request")
@@ -379,7 +384,7 @@ func (client GroupsClient) ListNextResults(lastResults ResourceGroupListResult) 
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -390,7 +395,7 @@ func (client GroupsClient) ListNextResults(lastResults ResourceGroupListResult) 
 // resourceGroupName is query parameters. If null is passed returns all
 // resource groups. filter is the filter to apply on the operation. top is
 // query parameters. If null is passed returns all resource groups.
-func (client GroupsClient) ListResources(resourceGroupName string, filter string, top *int) (result ResourceListResult, ae error) {
+func (client GroupsClient) ListResources(resourceGroupName string, filter string, top *int32) (result ResourceListResult, err error) {
 	req, err := client.ListResourcesPreparer(resourceGroupName, filter, top)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "ListResources", nil, "Failure preparing request")
@@ -404,14 +409,14 @@ func (client GroupsClient) ListResources(resourceGroupName string, filter string
 
 	result, err = client.ListResourcesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "ListResources", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "ListResources", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListResourcesPreparer prepares the ListResources request.
-func (client GroupsClient) ListResourcesPreparer(resourceGroupName string, filter string, top *int) (*http.Request, error) {
+func (client GroupsClient) ListResourcesPreparer(resourceGroupName string, filter string, top *int32) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -439,7 +444,7 @@ func (client GroupsClient) ListResourcesPreparer(resourceGroupName string, filte
 // ListResourcesSender sends the ListResources request. The method will close the
 // http.Response Body if it receives an error.
 func (client GroupsClient) ListResourcesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResourcesResponder handles the response to the ListResources request. The method always
@@ -456,7 +461,7 @@ func (client GroupsClient) ListResourcesResponder(resp *http.Response) (result R
 }
 
 // ListResourcesNextResults retrieves the next set of results, if any.
-func (client GroupsClient) ListResourcesNextResults(lastResults ResourceListResult) (result ResourceListResult, ae error) {
+func (client GroupsClient) ListResourcesNextResults(lastResults ResourceListResult) (result ResourceListResult, err error) {
 	req, err := lastResults.ResourceListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "ListResources", nil, "Failure preparing next results request request")
@@ -473,7 +478,7 @@ func (client GroupsClient) ListResourcesNextResults(lastResults ResourceListResu
 
 	result, err = client.ListResourcesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "ListResources", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "ListResources", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -487,7 +492,7 @@ func (client GroupsClient) ListResourcesNextResults(lastResults ResourceListResu
 // resourceGroupName is the name of the resource group to be created or
 // updated. The name is case insensitive. parameters is parameters supplied
 // to the update state resource group service operation.
-func (client GroupsClient) Patch(resourceGroupName string, parameters ResourceGroup) (result ResourceGroup, ae error) {
+func (client GroupsClient) Patch(resourceGroupName string, parameters ResourceGroup) (result ResourceGroup, err error) {
 	req, err := client.PatchPreparer(resourceGroupName, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "Patch", nil, "Failure preparing request")
@@ -501,7 +506,7 @@ func (client GroupsClient) Patch(resourceGroupName string, parameters ResourceGr
 
 	result, err = client.PatchResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/GroupsClient", "Patch", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/GroupsClient", "Patch", resp, "Failure responding to request")
 	}
 
 	return
@@ -531,7 +536,7 @@ func (client GroupsClient) PatchPreparer(resourceGroupName string, parameters Re
 // PatchSender sends the Patch request. The method will close the
 // http.Response Body if it receives an error.
 func (client GroupsClient) PatchSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // PatchResponder handles the response to the Patch request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/policyassignments.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/policyassignments.go
@@ -47,7 +47,7 @@ func NewPolicyAssignmentsClientWithBaseURI(baseURI string, subscriptionID string
 //
 // scope is scope. policyAssignmentName is policy assignment name. parameters
 // is policy assignment.
-func (client PolicyAssignmentsClient) Create(scope string, policyAssignmentName string, parameters PolicyAssignment) (result PolicyAssignment, ae error) {
+func (client PolicyAssignmentsClient) Create(scope string, policyAssignmentName string, parameters PolicyAssignment) (result PolicyAssignment, err error) {
 	req, err := client.CreatePreparer(scope, policyAssignmentName, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Create", nil, "Failure preparing request")
@@ -61,7 +61,7 @@ func (client PolicyAssignmentsClient) Create(scope string, policyAssignmentName 
 
 	result, err = client.CreateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Create", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Create", resp, "Failure responding to request")
 	}
 
 	return
@@ -92,7 +92,7 @@ func (client PolicyAssignmentsClient) CreatePreparer(scope string, policyAssignm
 // CreateSender sends the Create request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) CreateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateResponder handles the response to the Create request. The method always
@@ -111,7 +111,7 @@ func (client PolicyAssignmentsClient) CreateResponder(resp *http.Response) (resu
 // CreateByID create policy assignment by Id.
 //
 // policyAssignmentID is policy assignment Id parameters is policy assignment.
-func (client PolicyAssignmentsClient) CreateByID(policyAssignmentID string, parameters PolicyAssignment) (result PolicyAssignment, ae error) {
+func (client PolicyAssignmentsClient) CreateByID(policyAssignmentID string, parameters PolicyAssignment) (result PolicyAssignment, err error) {
 	req, err := client.CreateByIDPreparer(policyAssignmentID, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "CreateByID", nil, "Failure preparing request")
@@ -125,7 +125,7 @@ func (client PolicyAssignmentsClient) CreateByID(policyAssignmentID string, para
 
 	result, err = client.CreateByIDResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "CreateByID", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "CreateByID", resp, "Failure responding to request")
 	}
 
 	return
@@ -155,7 +155,7 @@ func (client PolicyAssignmentsClient) CreateByIDPreparer(policyAssignmentID stri
 // CreateByIDSender sends the CreateByID request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) CreateByIDSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateByIDResponder handles the response to the CreateByID request. The method always
@@ -174,7 +174,7 @@ func (client PolicyAssignmentsClient) CreateByIDResponder(resp *http.Response) (
 // Delete delete policy assignment.
 //
 // scope is scope. policyAssignmentName is policy assignment name.
-func (client PolicyAssignmentsClient) Delete(scope string, policyAssignmentName string) (result PolicyAssignment, ae error) {
+func (client PolicyAssignmentsClient) Delete(scope string, policyAssignmentName string) (result PolicyAssignment, err error) {
 	req, err := client.DeletePreparer(scope, policyAssignmentName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Delete", nil, "Failure preparing request")
@@ -188,7 +188,7 @@ func (client PolicyAssignmentsClient) Delete(scope string, policyAssignmentName 
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
@@ -218,7 +218,7 @@ func (client PolicyAssignmentsClient) DeletePreparer(scope string, policyAssignm
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -237,7 +237,7 @@ func (client PolicyAssignmentsClient) DeleteResponder(resp *http.Response) (resu
 // DeleteByID delete policy assignment.
 //
 // policyAssignmentID is policy assignment Id
-func (client PolicyAssignmentsClient) DeleteByID(policyAssignmentID string) (result PolicyAssignment, ae error) {
+func (client PolicyAssignmentsClient) DeleteByID(policyAssignmentID string) (result PolicyAssignment, err error) {
 	req, err := client.DeleteByIDPreparer(policyAssignmentID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "DeleteByID", nil, "Failure preparing request")
@@ -251,7 +251,7 @@ func (client PolicyAssignmentsClient) DeleteByID(policyAssignmentID string) (res
 
 	result, err = client.DeleteByIDResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "DeleteByID", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "DeleteByID", resp, "Failure responding to request")
 	}
 
 	return
@@ -280,7 +280,7 @@ func (client PolicyAssignmentsClient) DeleteByIDPreparer(policyAssignmentID stri
 // DeleteByIDSender sends the DeleteByID request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) DeleteByIDSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // DeleteByIDResponder handles the response to the DeleteByID request. The method always
@@ -299,7 +299,7 @@ func (client PolicyAssignmentsClient) DeleteByIDResponder(resp *http.Response) (
 // Get get single policy assignment.
 //
 // scope is scope. policyAssignmentName is policy assignment name.
-func (client PolicyAssignmentsClient) Get(scope string, policyAssignmentName string) (result PolicyAssignment, ae error) {
+func (client PolicyAssignmentsClient) Get(scope string, policyAssignmentName string) (result PolicyAssignment, err error) {
 	req, err := client.GetPreparer(scope, policyAssignmentName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Get", nil, "Failure preparing request")
@@ -313,7 +313,7 @@ func (client PolicyAssignmentsClient) Get(scope string, policyAssignmentName str
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -343,7 +343,7 @@ func (client PolicyAssignmentsClient) GetPreparer(scope string, policyAssignment
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -362,7 +362,7 @@ func (client PolicyAssignmentsClient) GetResponder(resp *http.Response) (result 
 // GetByID get single policy assignment.
 //
 // policyAssignmentID is policy assignment Id
-func (client PolicyAssignmentsClient) GetByID(policyAssignmentID string) (result PolicyAssignment, ae error) {
+func (client PolicyAssignmentsClient) GetByID(policyAssignmentID string) (result PolicyAssignment, err error) {
 	req, err := client.GetByIDPreparer(policyAssignmentID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "GetByID", nil, "Failure preparing request")
@@ -376,7 +376,7 @@ func (client PolicyAssignmentsClient) GetByID(policyAssignmentID string) (result
 
 	result, err = client.GetByIDResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "GetByID", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "GetByID", resp, "Failure responding to request")
 	}
 
 	return
@@ -405,7 +405,7 @@ func (client PolicyAssignmentsClient) GetByIDPreparer(policyAssignmentID string)
 // GetByIDSender sends the GetByID request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) GetByIDSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetByIDResponder handles the response to the GetByID request. The method always
@@ -424,7 +424,7 @@ func (client PolicyAssignmentsClient) GetByIDResponder(resp *http.Response) (res
 // List gets policy assignments of the subscription.
 //
 // filter is the filter to apply on the operation.
-func (client PolicyAssignmentsClient) List(filter string) (result PolicyAssignmentListResult, ae error) {
+func (client PolicyAssignmentsClient) List(filter string) (result PolicyAssignmentListResult, err error) {
 	req, err := client.ListPreparer(filter)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "List", nil, "Failure preparing request")
@@ -438,7 +438,7 @@ func (client PolicyAssignmentsClient) List(filter string) (result PolicyAssignme
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -469,7 +469,7 @@ func (client PolicyAssignmentsClient) ListPreparer(filter string) (*http.Request
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -486,7 +486,7 @@ func (client PolicyAssignmentsClient) ListResponder(resp *http.Response) (result
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client PolicyAssignmentsClient) ListNextResults(lastResults PolicyAssignmentListResult) (result PolicyAssignmentListResult, ae error) {
+func (client PolicyAssignmentsClient) ListNextResults(lastResults PolicyAssignmentListResult) (result PolicyAssignmentListResult, err error) {
 	req, err := lastResults.PolicyAssignmentListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "List", nil, "Failure preparing next results request request")
@@ -503,7 +503,7 @@ func (client PolicyAssignmentsClient) ListNextResults(lastResults PolicyAssignme
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -516,7 +516,7 @@ func (client PolicyAssignmentsClient) ListNextResults(lastResults PolicyAssignme
 // parentResourcePath is the parent resource path. resourceType is the
 // resource type. resourceName is the resource name. filter is the filter to
 // apply on the operation.
-func (client PolicyAssignmentsClient) ListForResource(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, filter string) (result PolicyAssignmentListResult, ae error) {
+func (client PolicyAssignmentsClient) ListForResource(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, filter string) (result PolicyAssignmentListResult, err error) {
 	req, err := client.ListForResourcePreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, filter)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResource", nil, "Failure preparing request")
@@ -530,7 +530,7 @@ func (client PolicyAssignmentsClient) ListForResource(resourceGroupName string, 
 
 	result, err = client.ListForResourceResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResource", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResource", resp, "Failure responding to request")
 	}
 
 	return
@@ -566,7 +566,7 @@ func (client PolicyAssignmentsClient) ListForResourcePreparer(resourceGroupName 
 // ListForResourceSender sends the ListForResource request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) ListForResourceSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListForResourceResponder handles the response to the ListForResource request. The method always
@@ -583,7 +583,7 @@ func (client PolicyAssignmentsClient) ListForResourceResponder(resp *http.Respon
 }
 
 // ListForResourceNextResults retrieves the next set of results, if any.
-func (client PolicyAssignmentsClient) ListForResourceNextResults(lastResults PolicyAssignmentListResult) (result PolicyAssignmentListResult, ae error) {
+func (client PolicyAssignmentsClient) ListForResourceNextResults(lastResults PolicyAssignmentListResult) (result PolicyAssignmentListResult, err error) {
 	req, err := lastResults.PolicyAssignmentListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResource", nil, "Failure preparing next results request request")
@@ -600,7 +600,7 @@ func (client PolicyAssignmentsClient) ListForResourceNextResults(lastResults Pol
 
 	result, err = client.ListForResourceResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResource", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResource", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -610,7 +610,7 @@ func (client PolicyAssignmentsClient) ListForResourceNextResults(lastResults Pol
 //
 // resourceGroupName is resource group name. filter is the filter to apply on
 // the operation.
-func (client PolicyAssignmentsClient) ListForResourceGroup(resourceGroupName string, filter string) (result PolicyAssignmentListResult, ae error) {
+func (client PolicyAssignmentsClient) ListForResourceGroup(resourceGroupName string, filter string) (result PolicyAssignmentListResult, err error) {
 	req, err := client.ListForResourceGroupPreparer(resourceGroupName, filter)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResourceGroup", nil, "Failure preparing request")
@@ -624,7 +624,7 @@ func (client PolicyAssignmentsClient) ListForResourceGroup(resourceGroupName str
 
 	result, err = client.ListForResourceGroupResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResourceGroup", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResourceGroup", resp, "Failure responding to request")
 	}
 
 	return
@@ -656,7 +656,7 @@ func (client PolicyAssignmentsClient) ListForResourceGroupPreparer(resourceGroup
 // ListForResourceGroupSender sends the ListForResourceGroup request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) ListForResourceGroupSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListForResourceGroupResponder handles the response to the ListForResourceGroup request. The method always
@@ -673,7 +673,7 @@ func (client PolicyAssignmentsClient) ListForResourceGroupResponder(resp *http.R
 }
 
 // ListForResourceGroupNextResults retrieves the next set of results, if any.
-func (client PolicyAssignmentsClient) ListForResourceGroupNextResults(lastResults PolicyAssignmentListResult) (result PolicyAssignmentListResult, ae error) {
+func (client PolicyAssignmentsClient) ListForResourceGroupNextResults(lastResults PolicyAssignmentListResult) (result PolicyAssignmentListResult, err error) {
 	req, err := lastResults.PolicyAssignmentListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResourceGroup", nil, "Failure preparing next results request request")
@@ -690,7 +690,7 @@ func (client PolicyAssignmentsClient) ListForResourceGroupNextResults(lastResult
 
 	result, err = client.ListForResourceGroupResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResourceGroup", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForResourceGroup", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -699,7 +699,7 @@ func (client PolicyAssignmentsClient) ListForResourceGroupNextResults(lastResult
 // ListForScope gets policy assignments of the scope.
 //
 // scope is scope. filter is the filter to apply on the operation.
-func (client PolicyAssignmentsClient) ListForScope(scope string, filter string) (result PolicyAssignmentListResult, ae error) {
+func (client PolicyAssignmentsClient) ListForScope(scope string, filter string) (result PolicyAssignmentListResult, err error) {
 	req, err := client.ListForScopePreparer(scope, filter)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForScope", nil, "Failure preparing request")
@@ -713,7 +713,7 @@ func (client PolicyAssignmentsClient) ListForScope(scope string, filter string) 
 
 	result, err = client.ListForScopeResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForScope", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForScope", resp, "Failure responding to request")
 	}
 
 	return
@@ -745,7 +745,7 @@ func (client PolicyAssignmentsClient) ListForScopePreparer(scope string, filter 
 // ListForScopeSender sends the ListForScope request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyAssignmentsClient) ListForScopeSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListForScopeResponder handles the response to the ListForScope request. The method always
@@ -762,7 +762,7 @@ func (client PolicyAssignmentsClient) ListForScopeResponder(resp *http.Response)
 }
 
 // ListForScopeNextResults retrieves the next set of results, if any.
-func (client PolicyAssignmentsClient) ListForScopeNextResults(lastResults PolicyAssignmentListResult) (result PolicyAssignmentListResult, ae error) {
+func (client PolicyAssignmentsClient) ListForScopeNextResults(lastResults PolicyAssignmentListResult) (result PolicyAssignmentListResult, err error) {
 	req, err := lastResults.PolicyAssignmentListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForScope", nil, "Failure preparing next results request request")
@@ -779,7 +779,7 @@ func (client PolicyAssignmentsClient) ListForScopeNextResults(lastResults Policy
 
 	result, err = client.ListForScopeResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForScope", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyAssignmentsClient", "ListForScope", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/policydefinitions.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/policydefinitions.go
@@ -47,7 +47,7 @@ func NewPolicyDefinitionsClientWithBaseURI(baseURI string, subscriptionID string
 //
 // policyDefinitionName is the policy definition name. parameters is the
 // policy definition properties
-func (client PolicyDefinitionsClient) CreateOrUpdate(policyDefinitionName string, parameters PolicyDefinition) (result PolicyDefinition, ae error) {
+func (client PolicyDefinitionsClient) CreateOrUpdate(policyDefinitionName string, parameters PolicyDefinition) (result PolicyDefinition, err error) {
 	req, err := client.CreateOrUpdatePreparer(policyDefinitionName, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "CreateOrUpdate", nil, "Failure preparing request")
@@ -61,7 +61,7 @@ func (client PolicyDefinitionsClient) CreateOrUpdate(policyDefinitionName string
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
@@ -91,7 +91,7 @@ func (client PolicyDefinitionsClient) CreateOrUpdatePreparer(policyDefinitionNam
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyDefinitionsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -110,7 +110,7 @@ func (client PolicyDefinitionsClient) CreateOrUpdateResponder(resp *http.Respons
 // Delete deletes policy definition.
 //
 // policyDefinitionName is the policy definition name.
-func (client PolicyDefinitionsClient) Delete(policyDefinitionName string) (result autorest.Response, ae error) {
+func (client PolicyDefinitionsClient) Delete(policyDefinitionName string) (result autorest.Response, err error) {
 	req, err := client.DeletePreparer(policyDefinitionName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "Delete", nil, "Failure preparing request")
@@ -124,7 +124,7 @@ func (client PolicyDefinitionsClient) Delete(policyDefinitionName string) (resul
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
@@ -153,7 +153,7 @@ func (client PolicyDefinitionsClient) DeletePreparer(policyDefinitionName string
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyDefinitionsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -171,7 +171,7 @@ func (client PolicyDefinitionsClient) DeleteResponder(resp *http.Response) (resu
 // Get gets policy definition.
 //
 // policyDefinitionName is the policy definition name.
-func (client PolicyDefinitionsClient) Get(policyDefinitionName string) (result PolicyDefinition, ae error) {
+func (client PolicyDefinitionsClient) Get(policyDefinitionName string) (result PolicyDefinition, err error) {
 	req, err := client.GetPreparer(policyDefinitionName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "Get", nil, "Failure preparing request")
@@ -185,7 +185,7 @@ func (client PolicyDefinitionsClient) Get(policyDefinitionName string) (result P
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/PolicyDefinitionsClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -214,7 +214,7 @@ func (client PolicyDefinitionsClient) GetPreparer(policyDefinitionName string) (
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client PolicyDefinitionsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/provideroperationdetails.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/provideroperationdetails.go
@@ -46,7 +46,7 @@ func NewProviderOperationDetailsClientWithBaseURI(baseURI string, subscriptionID
 // List gets a list of resource providers.
 //
 // resourceProviderNamespace is resource identity.
-func (client ProviderOperationDetailsClient) List(resourceProviderNamespace string, apiVersion string) (result ResourceProviderOperationDetailListResult, ae error) {
+func (client ProviderOperationDetailsClient) List(resourceProviderNamespace string, apiVersion string) (result ResourceProviderOperationDetailListResult, err error) {
 	req, err := client.ListPreparer(resourceProviderNamespace, apiVersion)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ProviderOperationDetailsClient", "List", nil, "Failure preparing request")
@@ -60,7 +60,7 @@ func (client ProviderOperationDetailsClient) List(resourceProviderNamespace stri
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ProviderOperationDetailsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ProviderOperationDetailsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -89,7 +89,7 @@ func (client ProviderOperationDetailsClient) ListPreparer(resourceProviderNamesp
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ProviderOperationDetailsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -106,7 +106,7 @@ func (client ProviderOperationDetailsClient) ListResponder(resp *http.Response) 
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ProviderOperationDetailsClient) ListNextResults(lastResults ResourceProviderOperationDetailListResult) (result ResourceProviderOperationDetailListResult, ae error) {
+func (client ProviderOperationDetailsClient) ListNextResults(lastResults ResourceProviderOperationDetailListResult) (result ResourceProviderOperationDetailListResult, err error) {
 	req, err := lastResults.ResourceProviderOperationDetailListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ProviderOperationDetailsClient", "List", nil, "Failure preparing next results request request")
@@ -123,7 +123,7 @@ func (client ProviderOperationDetailsClient) ListNextResults(lastResults Resourc
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ProviderOperationDetailsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/ProviderOperationDetailsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/providers.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/providers.go
@@ -45,7 +45,7 @@ func NewProvidersClientWithBaseURI(baseURI string, subscriptionID string) Provid
 // Get gets a resource provider.
 //
 // resourceProviderNamespace is namespace of the resource provider.
-func (client ProvidersClient) Get(resourceProviderNamespace string) (result Provider, ae error) {
+func (client ProvidersClient) Get(resourceProviderNamespace string) (result Provider, err error) {
 	req, err := client.GetPreparer(resourceProviderNamespace)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "Get", nil, "Failure preparing request")
@@ -59,7 +59,7 @@ func (client ProvidersClient) Get(resourceProviderNamespace string) (result Prov
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ProvidersClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ProvidersClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -88,7 +88,7 @@ func (client ProvidersClient) GetPreparer(resourceProviderNamespace string) (*ht
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client ProvidersClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -107,7 +107,7 @@ func (client ProvidersClient) GetResponder(resp *http.Response) (result Provider
 // List gets a list of resource providers.
 //
 // top is query parameters. If null is passed returns all deployments.
-func (client ProvidersClient) List(top *int) (result ProviderListResult, ae error) {
+func (client ProvidersClient) List(top *int32) (result ProviderListResult, err error) {
 	req, err := client.ListPreparer(top)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "List", nil, "Failure preparing request")
@@ -121,14 +121,14 @@ func (client ProvidersClient) List(top *int) (result ProviderListResult, ae erro
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ProvidersClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ProvidersClient", "List", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListPreparer prepares the List request.
-func (client ProvidersClient) ListPreparer(top *int) (*http.Request, error) {
+func (client ProvidersClient) ListPreparer(top *int32) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"subscriptionId": url.QueryEscape(client.SubscriptionID),
 	}
@@ -152,7 +152,7 @@ func (client ProvidersClient) ListPreparer(top *int) (*http.Request, error) {
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ProvidersClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -169,7 +169,7 @@ func (client ProvidersClient) ListResponder(resp *http.Response) (result Provide
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ProvidersClient) ListNextResults(lastResults ProviderListResult) (result ProviderListResult, ae error) {
+func (client ProvidersClient) ListNextResults(lastResults ProviderListResult) (result ProviderListResult, err error) {
 	req, err := lastResults.ProviderListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "List", nil, "Failure preparing next results request request")
@@ -186,7 +186,7 @@ func (client ProvidersClient) ListNextResults(lastResults ProviderListResult) (r
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ProvidersClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/ProvidersClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -195,7 +195,7 @@ func (client ProvidersClient) ListNextResults(lastResults ProviderListResult) (r
 // Register registers provider to be used with a subscription.
 //
 // resourceProviderNamespace is namespace of the resource provider.
-func (client ProvidersClient) Register(resourceProviderNamespace string) (result Provider, ae error) {
+func (client ProvidersClient) Register(resourceProviderNamespace string) (result Provider, err error) {
 	req, err := client.RegisterPreparer(resourceProviderNamespace)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "Register", nil, "Failure preparing request")
@@ -209,7 +209,7 @@ func (client ProvidersClient) Register(resourceProviderNamespace string) (result
 
 	result, err = client.RegisterResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ProvidersClient", "Register", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ProvidersClient", "Register", resp, "Failure responding to request")
 	}
 
 	return
@@ -238,7 +238,7 @@ func (client ProvidersClient) RegisterPreparer(resourceProviderNamespace string)
 // RegisterSender sends the Register request. The method will close the
 // http.Response Body if it receives an error.
 func (client ProvidersClient) RegisterSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // RegisterResponder handles the response to the Register request. The method always
@@ -257,7 +257,7 @@ func (client ProvidersClient) RegisterResponder(resp *http.Response) (result Pro
 // Unregister unregisters provider from a subscription.
 //
 // resourceProviderNamespace is namespace of the resource provider.
-func (client ProvidersClient) Unregister(resourceProviderNamespace string) (result Provider, ae error) {
+func (client ProvidersClient) Unregister(resourceProviderNamespace string) (result Provider, err error) {
 	req, err := client.UnregisterPreparer(resourceProviderNamespace)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "Unregister", nil, "Failure preparing request")
@@ -271,7 +271,7 @@ func (client ProvidersClient) Unregister(resourceProviderNamespace string) (resu
 
 	result, err = client.UnregisterResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/ProvidersClient", "Unregister", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/ProvidersClient", "Unregister", resp, "Failure responding to request")
 	}
 
 	return
@@ -300,7 +300,7 @@ func (client ProvidersClient) UnregisterPreparer(resourceProviderNamespace strin
 // UnregisterSender sends the Unregister request. The method will close the
 // http.Response Body if it receives an error.
 func (client ProvidersClient) UnregisterSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // UnregisterResponder handles the response to the Unregister request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/resources.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/resources.go
@@ -46,7 +46,7 @@ func NewClientWithBaseURI(baseURI string, subscriptionID string) Client {
 // insensitive. resourceProviderNamespace is resource identity.
 // parentResourcePath is resource identity. resourceType is resource
 // identity. resourceName is resource identity.
-func (client Client) CheckExistence(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result autorest.Response, ae error) {
+func (client Client) CheckExistence(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result autorest.Response, err error) {
 	req, err := client.CheckExistencePreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/Client", "CheckExistence", nil, "Failure preparing request")
@@ -60,7 +60,7 @@ func (client Client) CheckExistence(resourceGroupName string, resourceProviderNa
 
 	result, err = client.CheckExistenceResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/Client", "CheckExistence", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/Client", "CheckExistence", resp, "Failure responding to request")
 	}
 
 	return
@@ -93,7 +93,7 @@ func (client Client) CheckExistencePreparer(resourceGroupName string, resourcePr
 // CheckExistenceSender sends the CheckExistence request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) CheckExistenceSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CheckExistenceResponder handles the response to the CheckExistence request. The method always
@@ -115,7 +115,7 @@ func (client Client) CheckExistenceResponder(resp *http.Response) (result autore
 // parentResourcePath is resource identity. resourceType is resource
 // identity. resourceName is resource identity. parameters is create or
 // update resource parameters.
-func (client Client) CreateOrUpdate(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string, parameters GenericResource) (result GenericResource, ae error) {
+func (client Client) CreateOrUpdate(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string, parameters GenericResource) (result GenericResource, err error) {
 	req, err := client.CreateOrUpdatePreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, parameters)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/Client", "CreateOrUpdate", nil, "Failure preparing request")
@@ -129,7 +129,7 @@ func (client Client) CreateOrUpdate(resourceGroupName string, resourceProviderNa
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/Client", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/Client", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
@@ -163,7 +163,7 @@ func (client Client) CreateOrUpdatePreparer(resourceGroupName string, resourcePr
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -185,7 +185,7 @@ func (client Client) CreateOrUpdateResponder(resp *http.Response) (result Generi
 // insensitive. resourceProviderNamespace is resource identity.
 // parentResourcePath is resource identity. resourceType is resource
 // identity. resourceName is resource identity.
-func (client Client) Delete(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result autorest.Response, ae error) {
+func (client Client) Delete(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result autorest.Response, err error) {
 	req, err := client.DeletePreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/Client", "Delete", nil, "Failure preparing request")
@@ -199,7 +199,7 @@ func (client Client) Delete(resourceGroupName string, resourceProviderNamespace 
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/Client", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/Client", "Delete", resp, "Failure responding to request")
 	}
 
 	return
@@ -232,7 +232,7 @@ func (client Client) DeletePreparer(resourceGroupName string, resourceProviderNa
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -253,7 +253,7 @@ func (client Client) DeleteResponder(resp *http.Response) (result autorest.Respo
 // insensitive. resourceProviderNamespace is resource identity.
 // parentResourcePath is resource identity. resourceType is resource
 // identity. resourceName is resource identity.
-func (client Client) Get(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result GenericResource, ae error) {
+func (client Client) Get(resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, resourceName string, apiVersion string) (result GenericResource, err error) {
 	req, err := client.GetPreparer(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/Client", "Get", nil, "Failure preparing request")
@@ -267,7 +267,7 @@ func (client Client) Get(resourceGroupName string, resourceProviderNamespace str
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/Client", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/Client", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -300,7 +300,7 @@ func (client Client) GetPreparer(resourceGroupName string, resourceProviderNames
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -320,7 +320,7 @@ func (client Client) GetResponder(resp *http.Response) (result GenericResource, 
 //
 // filter is the filter to apply on the operation. top is query parameters. If
 // null is passed returns all resource groups.
-func (client Client) List(filter string, top *int) (result ResourceListResult, ae error) {
+func (client Client) List(filter string, top *int32) (result ResourceListResult, err error) {
 	req, err := client.ListPreparer(filter, top)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/Client", "List", nil, "Failure preparing request")
@@ -334,14 +334,14 @@ func (client Client) List(filter string, top *int) (result ResourceListResult, a
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/Client", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/Client", "List", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // ListPreparer prepares the List request.
-func (client Client) ListPreparer(filter string, top *int) (*http.Request, error) {
+func (client Client) ListPreparer(filter string, top *int32) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"subscriptionId": url.QueryEscape(client.SubscriptionID),
 	}
@@ -368,7 +368,7 @@ func (client Client) ListPreparer(filter string, top *int) (*http.Request, error
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -385,7 +385,7 @@ func (client Client) ListResponder(resp *http.Response) (result ResourceListResu
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client Client) ListNextResults(lastResults ResourceListResult) (result ResourceListResult, ae error) {
+func (client Client) ListNextResults(lastResults ResourceListResult) (result ResourceListResult, err error) {
 	req, err := lastResults.ResourceListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/Client", "List", nil, "Failure preparing next results request request")
@@ -402,19 +402,22 @@ func (client Client) ListNextResults(lastResults ResourceListResult) (result Res
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/Client", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/Client", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
 }
 
 // MoveResources begin moving resources.To determine whether the operation has
-// finished processing the request, call GetLongRunningOperationStatus.
+// finished processing the request, call GetLongRunningOperationStatus. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // sourceResourceGroupName is source resource group name. parameters is move
 // resources' parameters.
-func (client Client) MoveResources(sourceResourceGroupName string, parameters MoveInfo) (result autorest.Response, ae error) {
-	req, err := client.MoveResourcesPreparer(sourceResourceGroupName, parameters)
+func (client Client) MoveResources(sourceResourceGroupName string, parameters MoveInfo, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.MoveResourcesPreparer(sourceResourceGroupName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/Client", "MoveResources", nil, "Failure preparing request")
 	}
@@ -427,14 +430,14 @@ func (client Client) MoveResources(sourceResourceGroupName string, parameters Mo
 
 	result, err = client.MoveResourcesResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/Client", "MoveResources", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/Client", "MoveResources", resp, "Failure responding to request")
 	}
 
 	return
 }
 
 // MoveResourcesPreparer prepares the MoveResources request.
-func (client Client) MoveResourcesPreparer(sourceResourceGroupName string, parameters MoveInfo) (*http.Request, error) {
+func (client Client) MoveResourcesPreparer(sourceResourceGroupName string, parameters MoveInfo, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"sourceResourceGroupName": url.QueryEscape(sourceResourceGroupName),
 		"subscriptionId":          url.QueryEscape(client.SubscriptionID),
@@ -444,7 +447,7 @@ func (client Client) MoveResourcesPreparer(sourceResourceGroupName string, param
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -457,7 +460,9 @@ func (client Client) MoveResourcesPreparer(sourceResourceGroupName string, param
 // MoveResourcesSender sends the MoveResources request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) MoveResourcesSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client,
+		req,
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // MoveResourcesResponder handles the response to the MoveResources request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/tags.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/tags.go
@@ -43,7 +43,7 @@ func NewTagsClientWithBaseURI(baseURI string, subscriptionID string) TagsClient 
 // CreateOrUpdate create a subscription resource tag.
 //
 // tagName is the name of the tag.
-func (client TagsClient) CreateOrUpdate(tagName string) (result TagDetails, ae error) {
+func (client TagsClient) CreateOrUpdate(tagName string) (result TagDetails, err error) {
 	req, err := client.CreateOrUpdatePreparer(tagName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "CreateOrUpdate", nil, "Failure preparing request")
@@ -57,7 +57,7 @@ func (client TagsClient) CreateOrUpdate(tagName string) (result TagDetails, ae e
 
 	result, err = client.CreateOrUpdateResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/TagsClient", "CreateOrUpdate", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/TagsClient", "CreateOrUpdate", resp, "Failure responding to request")
 	}
 
 	return
@@ -86,7 +86,7 @@ func (client TagsClient) CreateOrUpdatePreparer(tagName string) (*http.Request, 
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client TagsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -105,7 +105,7 @@ func (client TagsClient) CreateOrUpdateResponder(resp *http.Response) (result Ta
 // CreateOrUpdateValue create a subscription resource tag value.
 //
 // tagName is the name of the tag. tagValue is the value of the tag.
-func (client TagsClient) CreateOrUpdateValue(tagName string, tagValue string) (result TagValue, ae error) {
+func (client TagsClient) CreateOrUpdateValue(tagName string, tagValue string) (result TagValue, err error) {
 	req, err := client.CreateOrUpdateValuePreparer(tagName, tagValue)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "CreateOrUpdateValue", nil, "Failure preparing request")
@@ -119,7 +119,7 @@ func (client TagsClient) CreateOrUpdateValue(tagName string, tagValue string) (r
 
 	result, err = client.CreateOrUpdateValueResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/TagsClient", "CreateOrUpdateValue", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/TagsClient", "CreateOrUpdateValue", resp, "Failure responding to request")
 	}
 
 	return
@@ -149,7 +149,7 @@ func (client TagsClient) CreateOrUpdateValuePreparer(tagName string, tagValue st
 // CreateOrUpdateValueSender sends the CreateOrUpdateValue request. The method will close the
 // http.Response Body if it receives an error.
 func (client TagsClient) CreateOrUpdateValueSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // CreateOrUpdateValueResponder handles the response to the CreateOrUpdateValue request. The method always
@@ -168,7 +168,7 @@ func (client TagsClient) CreateOrUpdateValueResponder(resp *http.Response) (resu
 // Delete delete a subscription resource tag.
 //
 // tagName is the name of the tag.
-func (client TagsClient) Delete(tagName string) (result autorest.Response, ae error) {
+func (client TagsClient) Delete(tagName string) (result autorest.Response, err error) {
 	req, err := client.DeletePreparer(tagName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "Delete", nil, "Failure preparing request")
@@ -182,7 +182,7 @@ func (client TagsClient) Delete(tagName string) (result autorest.Response, ae er
 
 	result, err = client.DeleteResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/TagsClient", "Delete", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/TagsClient", "Delete", resp, "Failure responding to request")
 	}
 
 	return
@@ -211,7 +211,7 @@ func (client TagsClient) DeletePreparer(tagName string) (*http.Request, error) {
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client TagsClient) DeleteSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -229,7 +229,7 @@ func (client TagsClient) DeleteResponder(resp *http.Response) (result autorest.R
 // DeleteValue delete a subscription resource tag value.
 //
 // tagName is the name of the tag. tagValue is the value of the tag.
-func (client TagsClient) DeleteValue(tagName string, tagValue string) (result autorest.Response, ae error) {
+func (client TagsClient) DeleteValue(tagName string, tagValue string) (result autorest.Response, err error) {
 	req, err := client.DeleteValuePreparer(tagName, tagValue)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "DeleteValue", nil, "Failure preparing request")
@@ -243,7 +243,7 @@ func (client TagsClient) DeleteValue(tagName string, tagValue string) (result au
 
 	result, err = client.DeleteValueResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/TagsClient", "DeleteValue", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/TagsClient", "DeleteValue", resp, "Failure responding to request")
 	}
 
 	return
@@ -273,7 +273,7 @@ func (client TagsClient) DeleteValuePreparer(tagName string, tagValue string) (*
 // DeleteValueSender sends the DeleteValue request. The method will close the
 // http.Response Body if it receives an error.
 func (client TagsClient) DeleteValueSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // DeleteValueResponder handles the response to the DeleteValue request. The method always
@@ -289,7 +289,7 @@ func (client TagsClient) DeleteValueResponder(resp *http.Response) (result autor
 }
 
 // List get a list of subscription resource tags.
-func (client TagsClient) List() (result TagsListResult, ae error) {
+func (client TagsClient) List() (result TagsListResult, err error) {
 	req, err := client.ListPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "List", nil, "Failure preparing request")
@@ -303,7 +303,7 @@ func (client TagsClient) List() (result TagsListResult, ae error) {
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/TagsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "resources/TagsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -331,7 +331,7 @@ func (client TagsClient) ListPreparer() (*http.Request, error) {
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client TagsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -348,7 +348,7 @@ func (client TagsClient) ListResponder(resp *http.Response) (result TagsListResu
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client TagsClient) ListNextResults(lastResults TagsListResult) (result TagsListResult, ae error) {
+func (client TagsClient) ListNextResults(lastResults TagsListResult) (result TagsListResult, err error) {
 	req, err := lastResults.TagsListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "List", nil, "Failure preparing next results request request")
@@ -365,7 +365,7 @@ func (client TagsClient) ListNextResults(lastResults TagsListResult) (result Tag
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "resources/TagsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "resources/TagsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "5"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/client.go
@@ -60,7 +60,7 @@ func NewWithBaseURI(baseURI string, subscriptionID string) ManagementClient {
 // Get gets details about particular subscription.
 //
 // subscriptionID is id of the subscription.
-func (client ManagementClient) Get(subscriptionID string) (result Subscription, ae error) {
+func (client ManagementClient) Get(subscriptionID string) (result Subscription, err error) {
 	req, err := client.GetPreparer(subscriptionID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "Get", nil, "Failure preparing request")
@@ -74,7 +74,7 @@ func (client ManagementClient) Get(subscriptionID string) (result Subscription, 
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -102,7 +102,7 @@ func (client ManagementClient) GetPreparer(subscriptionID string) (*http.Request
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -119,7 +119,7 @@ func (client ManagementClient) GetResponder(resp *http.Response) (result Subscri
 }
 
 // List gets a list of the subscriptionIds.
-func (client ManagementClient) List() (result SubscriptionListResult, ae error) {
+func (client ManagementClient) List() (result SubscriptionListResult, err error) {
 	req, err := client.ListPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "List", nil, "Failure preparing request")
@@ -133,7 +133,7 @@ func (client ManagementClient) List() (result SubscriptionListResult, ae error) 
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -156,7 +156,7 @@ func (client ManagementClient) ListPreparer() (*http.Request, error) {
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -173,7 +173,7 @@ func (client ManagementClient) ListResponder(resp *http.Response) (result Subscr
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client ManagementClient) ListNextResults(lastResults SubscriptionListResult) (result SubscriptionListResult, ae error) {
+func (client ManagementClient) ListNextResults(lastResults SubscriptionListResult) (result SubscriptionListResult, err error) {
 	req, err := lastResults.SubscriptionListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "List", nil, "Failure preparing next results request request")
@@ -190,7 +190,7 @@ func (client ManagementClient) ListNextResults(lastResults SubscriptionListResul
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -199,7 +199,7 @@ func (client ManagementClient) ListNextResults(lastResults SubscriptionListResul
 // ListLocations gets a list of the subscription locations.
 //
 // subscriptionID is id of the subscription
-func (client ManagementClient) ListLocations(subscriptionID string) (result LocationListResult, ae error) {
+func (client ManagementClient) ListLocations(subscriptionID string) (result LocationListResult, err error) {
 	req, err := client.ListLocationsPreparer(subscriptionID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "ListLocations", nil, "Failure preparing request")
@@ -213,7 +213,7 @@ func (client ManagementClient) ListLocations(subscriptionID string) (result Loca
 
 	result, err = client.ListLocationsResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "ListLocations", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "ListLocations", resp, "Failure responding to request")
 	}
 
 	return
@@ -241,7 +241,7 @@ func (client ManagementClient) ListLocationsPreparer(subscriptionID string) (*ht
 // ListLocationsSender sends the ListLocations request. The method will close the
 // http.Response Body if it receives an error.
 func (client ManagementClient) ListLocationsSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListLocationsResponder handles the response to the ListLocations request. The method always
@@ -258,7 +258,7 @@ func (client ManagementClient) ListLocationsResponder(resp *http.Response) (resu
 }
 
 // ListLocationsNextResults retrieves the next set of results, if any.
-func (client ManagementClient) ListLocationsNextResults(lastResults LocationListResult) (result LocationListResult, ae error) {
+func (client ManagementClient) ListLocationsNextResults(lastResults LocationListResult) (result LocationListResult, err error) {
 	req, err := lastResults.LocationListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "ListLocations", nil, "Failure preparing next results request request")
@@ -275,7 +275,7 @@ func (client ManagementClient) ListLocationsNextResults(lastResults LocationList
 
 	result, err = client.ListLocationsResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "ListLocations", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "ListLocations", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/subscriptions.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/subscriptions.go
@@ -44,7 +44,7 @@ func NewClientWithBaseURI(baseURI string, subscriptionID string) Client {
 // Get gets details about particular subscription.
 //
 // subscriptionID is id of the subscription.
-func (client Client) Get(subscriptionID string) (result Subscription, ae error) {
+func (client Client) Get(subscriptionID string) (result Subscription, err error) {
 	req, err := client.GetPreparer(subscriptionID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/Client", "Get", nil, "Failure preparing request")
@@ -58,7 +58,7 @@ func (client Client) Get(subscriptionID string) (result Subscription, ae error) 
 
 	result, err = client.GetResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/Client", "Get", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "subscriptions/Client", "Get", resp, "Failure responding to request")
 	}
 
 	return
@@ -86,7 +86,7 @@ func (client Client) GetPreparer(subscriptionID string) (*http.Request, error) {
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) GetSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -103,7 +103,7 @@ func (client Client) GetResponder(resp *http.Response) (result Subscription, err
 }
 
 // List gets a list of the subscriptionIds.
-func (client Client) List() (result SubscriptionListResult, ae error) {
+func (client Client) List() (result SubscriptionListResult, err error) {
 	req, err := client.ListPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/Client", "List", nil, "Failure preparing request")
@@ -117,7 +117,7 @@ func (client Client) List() (result SubscriptionListResult, ae error) {
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/Client", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "subscriptions/Client", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -140,7 +140,7 @@ func (client Client) ListPreparer() (*http.Request, error) {
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -157,7 +157,7 @@ func (client Client) ListResponder(resp *http.Response) (result SubscriptionList
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client Client) ListNextResults(lastResults SubscriptionListResult) (result SubscriptionListResult, ae error) {
+func (client Client) ListNextResults(lastResults SubscriptionListResult) (result SubscriptionListResult, err error) {
 	req, err := lastResults.SubscriptionListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/Client", "List", nil, "Failure preparing next results request request")
@@ -174,7 +174,7 @@ func (client Client) ListNextResults(lastResults SubscriptionListResult) (result
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/Client", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "subscriptions/Client", "List", resp, "Failure responding to next results request request")
 	}
 
 	return
@@ -183,7 +183,7 @@ func (client Client) ListNextResults(lastResults SubscriptionListResult) (result
 // ListLocations gets a list of the subscription locations.
 //
 // subscriptionID is id of the subscription
-func (client Client) ListLocations(subscriptionID string) (result LocationListResult, ae error) {
+func (client Client) ListLocations(subscriptionID string) (result LocationListResult, err error) {
 	req, err := client.ListLocationsPreparer(subscriptionID)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/Client", "ListLocations", nil, "Failure preparing request")
@@ -197,7 +197,7 @@ func (client Client) ListLocations(subscriptionID string) (result LocationListRe
 
 	result, err = client.ListLocationsResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/Client", "ListLocations", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "subscriptions/Client", "ListLocations", resp, "Failure responding to request")
 	}
 
 	return
@@ -225,7 +225,7 @@ func (client Client) ListLocationsPreparer(subscriptionID string) (*http.Request
 // ListLocationsSender sends the ListLocations request. The method will close the
 // http.Response Body if it receives an error.
 func (client Client) ListLocationsSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListLocationsResponder handles the response to the ListLocations request. The method always
@@ -242,7 +242,7 @@ func (client Client) ListLocationsResponder(resp *http.Response) (result Locatio
 }
 
 // ListLocationsNextResults retrieves the next set of results, if any.
-func (client Client) ListLocationsNextResults(lastResults LocationListResult) (result LocationListResult, ae error) {
+func (client Client) ListLocationsNextResults(lastResults LocationListResult) (result LocationListResult, err error) {
 	req, err := lastResults.LocationListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/Client", "ListLocations", nil, "Failure preparing next results request request")
@@ -259,7 +259,7 @@ func (client Client) ListLocationsNextResults(lastResults LocationListResult) (r
 
 	result, err = client.ListLocationsResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/Client", "ListLocations", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "subscriptions/Client", "ListLocations", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/tenants.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/tenants.go
@@ -41,7 +41,7 @@ func NewTenantsClientWithBaseURI(baseURI string, subscriptionID string) TenantsC
 }
 
 // List gets a list of the tenantIds.
-func (client TenantsClient) List() (result TenantListResult, ae error) {
+func (client TenantsClient) List() (result TenantListResult, err error) {
 	req, err := client.ListPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/TenantsClient", "List", nil, "Failure preparing request")
@@ -55,7 +55,7 @@ func (client TenantsClient) List() (result TenantListResult, ae error) {
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/TenantsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "subscriptions/TenantsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -78,7 +78,7 @@ func (client TenantsClient) ListPreparer() (*http.Request, error) {
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client TenantsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -95,7 +95,7 @@ func (client TenantsClient) ListResponder(resp *http.Response) (result TenantLis
 }
 
 // ListNextResults retrieves the next set of results, if any.
-func (client TenantsClient) ListNextResults(lastResults TenantListResult) (result TenantListResult, ae error) {
+func (client TenantsClient) ListNextResults(lastResults TenantListResult) (result TenantListResult, err error) {
 	req, err := lastResults.TenantListResultPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "subscriptions/TenantsClient", "List", nil, "Failure preparing next results request request")
@@ -112,7 +112,7 @@ func (client TenantsClient) ListNextResults(lastResults TenantListResult) (resul
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "subscriptions/TenantsClient", "List", resp, "Failure responding to next results request request")
+		err = autorest.NewErrorWithError(err, "subscriptions/TenantsClient", "List", resp, "Failure responding to next results request request")
 	}
 
 	return

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "5"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/client.go
@@ -1,7 +1,7 @@
 // Package storage implements the Azure ARM Storage service API version
 // 2015-06-15.
 //
-// The Storage Management Client..
+// The Storage Management Client.
 package storage
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/models.go
@@ -199,8 +199,8 @@ type Resource struct {
 // Usage is describes Storage Resource Usage.
 type Usage struct {
 	Unit         UsageUnit  `json:"unit,omitempty"`
-	CurrentValue *int       `json:"currentValue,omitempty"`
-	Limit        *int       `json:"limit,omitempty"`
+	CurrentValue *int32     `json:"currentValue,omitempty"`
+	Limit        *int32     `json:"limit,omitempty"`
 	Name         *UsageName `json:"name,omitempty"`
 }
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/usageoperations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/usageoperations.go
@@ -44,7 +44,7 @@ func NewUsageOperationsClientWithBaseURI(baseURI string, subscriptionID string) 
 
 // List gets the current usage count and the limit for the resources under the
 // subscription.
-func (client UsageOperationsClient) List() (result UsageListResult, ae error) {
+func (client UsageOperationsClient) List() (result UsageListResult, err error) {
 	req, err := client.ListPreparer()
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "storage/UsageOperationsClient", "List", nil, "Failure preparing request")
@@ -58,7 +58,7 @@ func (client UsageOperationsClient) List() (result UsageListResult, ae error) {
 
 	result, err = client.ListResponder(resp)
 	if err != nil {
-		ae = autorest.NewErrorWithError(err, "storage/UsageOperationsClient", "List", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "storage/UsageOperationsClient", "List", resp, "Failure responding to request")
 	}
 
 	return
@@ -86,7 +86,7 @@ func (client UsageOperationsClient) ListPreparer() (*http.Request, error) {
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client UsageOperationsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req)
+	return autorest.SendWithSender(client, req)
 }
 
 // ListResponder handles the response to the List request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "5"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/blob.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/blob.go
@@ -88,6 +88,16 @@ type BlobListResponse struct {
 	NextMarker string   `xml:"NextMarker"`
 	MaxResults int64    `xml:"MaxResults"`
 	Blobs      []Blob   `xml:"Blobs>Blob"`
+
+	// BlobPrefix is used to traverse blobs as if it were a file system.
+	// It is returned if ListBlobsParameters.Delimiter is specified.
+	// The list here can be thought of as "folders" that may contain
+	// other folders or blobs.
+	BlobPrefixes []string `xml:"Blobs>BlobPrefix>Name"`
+
+	// Delimiter is used to traverse blobs as if it were a file system.
+	// It is returned if ListBlobsParameters.Delimiter is specified.
+	Delimiter string `xml:"Delimiter"`
 }
 
 // ListContainersParameters defines the set of customizable parameters to make a
@@ -749,14 +759,16 @@ func (b BlobStorageClient) PutPageBlob(container, name string, size int64, extra
 // with 512-byte boundaries and chunk must be of size multiplies by 512.
 //
 // See https://msdn.microsoft.com/en-us/library/ee691975.aspx
-func (b BlobStorageClient) PutPage(container, name string, startByte, endByte int64, writeType PageWriteType, chunk []byte) error {
+func (b BlobStorageClient) PutPage(container, name string, startByte, endByte int64, writeType PageWriteType, chunk []byte, extraHeaders map[string]string) error {
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{"comp": {"page"}})
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypePage)
 	headers["x-ms-page-write"] = string(writeType)
 	headers["x-ms-range"] = fmt.Sprintf("bytes=%v-%v", startByte, endByte)
-
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
 	var contentLength int64
 	var data io.Reader
 	if writeType == PageWriteTypeClear {
@@ -825,12 +837,16 @@ func (b BlobStorageClient) PutAppendBlob(container, name string, extraHeaders ma
 // AppendBlock appends a block to an append blob.
 //
 // See https://msdn.microsoft.com/en-us/library/azure/mt427365.aspx
-func (b BlobStorageClient) AppendBlock(container, name string, chunk []byte) error {
+func (b BlobStorageClient) AppendBlock(container, name string, chunk []byte, extraHeaders map[string]string) error {
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{"comp": {"appendblock"}})
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypeAppend)
 	headers["Content-Length"] = fmt.Sprintf("%v", len(chunk))
+
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
 
 	resp, err := b.client.exec("PUT", uri, headers, bytes.NewReader(chunk))
 	if err != nil {
@@ -908,8 +924,8 @@ func (b BlobStorageClient) waitForBlobCopy(container, name, copyID string) error
 // DeleteBlob deletes the given blob from the specified container.
 // If the blob does not exists at the time of the Delete Blob operation, it
 // returns error. See https://msdn.microsoft.com/en-us/library/azure/dd179413.aspx
-func (b BlobStorageClient) DeleteBlob(container, name string) error {
-	resp, err := b.deleteBlob(container, name)
+func (b BlobStorageClient) DeleteBlob(container, name string, extraHeaders map[string]string) error {
+	resp, err := b.deleteBlob(container, name, extraHeaders)
 	if err != nil {
 		return err
 	}
@@ -921,8 +937,8 @@ func (b BlobStorageClient) DeleteBlob(container, name string) error {
 // blob is deleted with this call, returns true. Otherwise returns false.
 //
 // See https://msdn.microsoft.com/en-us/library/azure/dd179413.aspx
-func (b BlobStorageClient) DeleteBlobIfExists(container, name string) (bool, error) {
-	resp, err := b.deleteBlob(container, name)
+func (b BlobStorageClient) DeleteBlobIfExists(container, name string, extraHeaders map[string]string) (bool, error) {
+	resp, err := b.deleteBlob(container, name, extraHeaders)
 	if resp != nil && (resp.statusCode == http.StatusAccepted || resp.statusCode == http.StatusNotFound) {
 		return resp.statusCode == http.StatusAccepted, nil
 	}
@@ -930,10 +946,13 @@ func (b BlobStorageClient) DeleteBlobIfExists(container, name string) (bool, err
 	return false, err
 }
 
-func (b BlobStorageClient) deleteBlob(container, name string) (*storageResponse, error) {
+func (b BlobStorageClient) deleteBlob(container, name string, extraHeaders map[string]string) (*storageResponse, error) {
 	verb := "DELETE"
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 	headers := b.client.getStandardHeaders()
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
 
 	return b.client.exec(verb, uri, headers, nil)
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/client.go
@@ -37,6 +37,10 @@ const (
 // Client is the object that needs to be constructed to perform
 // operations on the storage account.
 type Client struct {
+	// HTTPClient is the http.Client used to initiate API
+	// requests.  If it is nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+
 	accountName string
 	accountKey  []byte
 	useHTTPS    bool
@@ -318,7 +322,11 @@ func (c Client) exec(verb, url string, headers map[string]string, body io.Reader
 	for k, v := range headers {
 		req.Header.Add(k, v)
 	}
-	httpClient := http.Client{}
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
@@ -1,0 +1,275 @@
+package azure
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/date"
+)
+
+const (
+	headerAsyncOperation = "Azure-AsyncOperation"
+)
+
+const (
+	methodDelete = "DELETE"
+	methodPatch  = "PATCH"
+	methodPost   = "POST"
+	methodPut    = "PUT"
+	methodGet    = "GET"
+
+	operationInProgress string = "InProgress"
+	operationCanceled   string = "Canceled"
+	operationFailed     string = "Failed"
+	operationSucceeded  string = "Succeeded"
+)
+
+// DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
+// long-running operation. It will delay between requests for the duration specified in the
+// RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
+// closing the optional channel on the http.Request.
+func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			resp, err = s.Do(r)
+			if err != nil {
+				return resp, err
+			}
+
+			ps := pollingState{}
+			for err == nil {
+				err = updatePollingState(resp, &ps)
+				if err != nil {
+					break
+				}
+				if ps.hasTerminated() {
+					if !ps.hasSucceeded() {
+						err = autorest.NewError("azure", "DoPollForAsynchronous", "Polling terminated with status '%s'", ps.state)
+					}
+					break
+				}
+
+				r, err = newPollingRequest(resp, ps)
+				if err != nil {
+					return resp, err
+				}
+
+				resp, err = autorest.SendWithSender(s, r,
+					autorest.AfterDelay(autorest.GetRetryAfter(resp, delay)))
+			}
+
+			return resp, err
+		})
+	}
+}
+
+func getAsyncOperation(resp *http.Response) string {
+	return resp.Header.Get(http.CanonicalHeaderKey(headerAsyncOperation))
+}
+
+func hasSucceeded(state string) bool {
+	return state == operationSucceeded
+}
+
+func hasTerminated(state string) bool {
+	switch state {
+	case operationCanceled, operationFailed, operationSucceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+type provisioningTracker interface {
+	state() string
+	hasSucceeded() bool
+	hasTerminated() bool
+}
+
+type operationError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (oe operationError) Error() string {
+	return fmt.Sprintf("Azure Operation Error: Code=%q Message=%q", oe.Code, oe.Message)
+}
+
+type operationResource struct {
+	// Note:
+	// 	The specification states services should return the "id" field. However some return it as
+	// 	"operationId".
+	ID              string                 `json:"id"`
+	OperationID     string                 `json:"operationId"`
+	Name            string                 `json:"name"`
+	Status          string                 `json:"status"`
+	Properties      map[string]interface{} `json:"properties"`
+	OperationError  operationError         `json:"error"`
+	StartTime       date.Time              `json:"startTime"`
+	EndTime         date.Time              `json:"endTime"`
+	PercentComplete float64                `json:"percentComplete"`
+}
+
+func (or operationResource) state() string {
+	return or.Status
+}
+
+func (or operationResource) hasSucceeded() bool {
+	return hasSucceeded(or.state())
+}
+
+func (or operationResource) hasTerminated() bool {
+	return hasTerminated(or.state())
+}
+
+type provisioningProperties struct {
+	ProvisioningState string `json:"provisioningState"`
+}
+
+type provisioningStatus struct {
+	Properties provisioningProperties `json:"properties"`
+}
+
+func (ps provisioningStatus) state() string {
+	return ps.Properties.ProvisioningState
+}
+
+func (ps provisioningStatus) hasSucceeded() bool {
+	return hasSucceeded(ps.state())
+}
+
+func (ps provisioningStatus) hasTerminated() bool {
+	return hasTerminated(ps.state())
+}
+
+type pollingResponseFormat string
+
+const (
+	usesOperationResponse  pollingResponseFormat = "OperationResponse"
+	usesProvisioningStatus pollingResponseFormat = "ProvisioningStatus"
+	formatIsUnknown        pollingResponseFormat = ""
+)
+
+type pollingState struct {
+	responseFormat pollingResponseFormat
+	uri            string
+	state          string
+	code           string
+	message        string
+}
+
+func (ps pollingState) hasSucceeded() bool {
+	return hasSucceeded(ps.state)
+}
+
+func (ps pollingState) hasTerminated() bool {
+	return hasTerminated(ps.state)
+}
+
+//	updatePollingState maps the operation status -- retrieved from either a provisioningState
+// 	field, the status field of an OperationResource, or inferred from the HTTP status code --
+// 	into a well-known states. Since the process begins from the initial request, the state
+//	always comes from either a the provisioningState returned or is inferred from the HTTP
+//	status code. Subsequent requests will read an Azure OperationResource object if the
+//	service initially returned the Azure-AsyncOperation header. The responseFormat field notes
+//	the expected response format.
+func updatePollingState(resp *http.Response, ps *pollingState) error {
+	// Determine the response shape
+	// -- The first response will always be a provisioningStatus response; only the polling requests,
+	//    depending on the header returned, may be something otherwise.
+	var pt provisioningTracker
+	if ps.responseFormat == usesOperationResponse {
+		pt = &operationResource{}
+	} else {
+		pt = &provisioningStatus{}
+	}
+
+	// If this is the first request (that is, the polling response shape is unknown), determine how
+	// to poll and what to expect
+	if ps.responseFormat == formatIsUnknown {
+		req := resp.Request
+		if req == nil {
+			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Original HTTP request is missing")
+		}
+
+		// Prefer the Azure-AsyncOperation header
+		ps.uri = getAsyncOperation(resp)
+		if ps.uri != "" {
+			ps.responseFormat = usesOperationResponse
+		} else {
+			ps.responseFormat = usesProvisioningStatus
+		}
+
+		// Else, use the Location header
+		if ps.uri == "" {
+			ps.uri = autorest.GetLocation(resp)
+		}
+
+		// Lastly, requests against an existing resource, use the last request URI
+		if ps.uri == "" {
+			m := strings.ToUpper(req.Method)
+			if m == methodPatch || m == methodPut || m == methodGet {
+				ps.uri = req.URL.String()
+			}
+		}
+
+		if ps.uri == "" {
+			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", req.Method, req.RequestURI)
+		}
+	}
+
+	// Read and interpret the response (saving the Body in case no polling is necessary)
+	b := &bytes.Buffer{}
+	err := autorest.Respond(resp,
+		autorest.ByCopying(b),
+		autorest.ByUnmarshallingJSON(pt),
+		autorest.ByClosing())
+	resp.Body = ioutil.NopCloser(b)
+	if err != nil {
+		return err
+	}
+
+	// Interpret the results
+	// -- Terminal states apply regardless
+	// -- Unknown states are per-service inprogress states
+	// -- Otherwise, infer state from HTTP status code
+	if pt.hasTerminated() {
+		ps.state = pt.state()
+	} else if pt.state() != "" {
+		ps.state = operationInProgress
+	} else {
+		switch resp.StatusCode {
+		case http.StatusAccepted:
+			ps.state = operationInProgress
+
+		case http.StatusNoContent, http.StatusCreated, http.StatusOK:
+			ps.state = operationSucceeded
+
+		default:
+			ps.state = operationFailed
+		}
+	}
+
+	return nil
+}
+
+func newPollingRequest(resp *http.Response, ps pollingState) (*http.Request, error) {
+	req := resp.Request
+	if req == nil {
+		return nil, autorest.NewError("azure", "newPollingRequest", "Azure Polling Error - Original HTTP request is missing")
+	}
+
+	reqPoll, err := autorest.Prepare(&http.Request{Cancel: req.Cancel},
+		autorest.AsGet(),
+		autorest.WithBaseURL(ps.uri))
+	if err != nil {
+		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.uri)
+	}
+
+	return reqPoll, nil
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/azure.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/azure.go
@@ -10,16 +10,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/Azure/go-autorest/autorest"
 )
 
 const (
-	// HeaderAsyncOperation is the Azure header containing the location to poll for long-running
-	// operations.
-	HeaderAsyncOperation = "Azure-AsyncOperation"
-
 	// HeaderClientID is the Azure extension header to set a user-specified request ID.
 	HeaderClientID = "x-ms-client-request-id"
 
@@ -129,57 +124,6 @@ func ExtractClientID(resp *http.Response) string {
 // x-ms-request-id header.
 func ExtractRequestID(resp *http.Response) string {
 	return autorest.ExtractHeaderValue(HeaderRequestID, resp)
-}
-
-// GetAsyncOperation retrieves the long-running URL to poll from the passed response.
-func GetAsyncOperation(resp *http.Response) string {
-	return resp.Header.Get(http.CanonicalHeaderKey(HeaderAsyncOperation))
-}
-
-// ResponseIsLongRunning returns true if the passed response is for an Azure long-running operation.
-func ResponseIsLongRunning(resp *http.Response) bool {
-	return autorest.ResponseRequiresPolling(resp, http.StatusCreated) && GetAsyncOperation(resp) != ""
-}
-
-// NewAsyncPollingRequest allocates and returns a new http.Request to poll an Azure long-running
-// operation. If it successfully creates the request, it will also close the body of the passed
-// response, otherwise the body remains open.
-func NewAsyncPollingRequest(resp *http.Response, c autorest.Client) (*http.Request, error) {
-	location := GetAsyncOperation(resp)
-	if location == "" {
-		return nil, autorest.NewErrorWithResponse("azure", "NewAsyncPollingRequest", resp, "Azure-AsyncOperation header missing from response that requires polling")
-	}
-
-	req, err := autorest.Prepare(&http.Request{},
-		autorest.AsGet(),
-		autorest.WithBaseURL(location))
-	if err != nil {
-		return nil, autorest.NewErrorWithError(err, "azure", "NewAsyncPollingRequest", nil, "Failure creating poll request to %s", location)
-	}
-
-	autorest.Respond(resp,
-		c.ByInspecting(),
-		autorest.ByClosing())
-
-	return req, nil
-}
-
-// WithAsyncPolling will poll until the completion of an Azure long-running operation. The delay
-// time between requests is taken from the HTTP Retry-After header, if present, or the passed
-// delay otherwise. Polling may be canceled by signaling on the optional http.Request channel.
-func WithAsyncPolling(defaultDelay time.Duration) autorest.SendDecorator {
-	return func(s autorest.Sender) autorest.Sender {
-		return autorest.SenderFunc(func(r *http.Request) (*http.Response, error) {
-			resp, err := s.Do(r)
-			for err == nil && ResponseIsLongRunning(resp) {
-				err = autorest.DelayForBackoff(autorest.GetPollingDelay(resp, defaultDelay), 1, r.Cancel)
-				if err == nil {
-					resp, err = s.Do(r)
-				}
-			}
-			return resp, err
-		})
-	}
 }
 
 // WithErrorUnlessStatusCode returns a RespondDecorator that emits an

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/devicetoken.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/devicetoken.go
@@ -91,7 +91,7 @@ func InitiateDeviceAuth(client *autorest.Client, oauthConfig OAuthConfig, client
 		}),
 	)
 
-	resp, err := client.Send(req)
+	resp, err := autorest.SendWithSender(client, req)
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: %s", logPrefix, errCodeSendingFails, err)
 	}
@@ -129,7 +129,7 @@ func CheckForUserCompletion(client *autorest.Client, code *DeviceCode) (*Token, 
 		}),
 	)
 
-	resp, err := client.Send(req)
+	resp, err := autorest.SendWithSender(client, req)
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: %s", logPrefix, errTokenSendingFails, err)
 	}

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/persist.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/persist.go
@@ -43,6 +43,9 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 	if json.NewEncoder(newFile).Encode(token); err != nil {
 		return fmt.Errorf("failed to encode token to file (%s) while saving token: %v", tempPath, err)
 	}
+	if err := newFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file %s: %v", tempPath, err)
+	}
 
 	// Atomic replace to avoid multi-writer file corruptions
 	if err := os.Rename(tempPath, path); err != nil {

--- a/vendor/github.com/Azure/go-autorest/autorest/date/date.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/date.go
@@ -7,17 +7,14 @@ package date
 
 import (
 	"fmt"
-	"github.com/Azure/go-autorest/autorest"
-	"io"
-	"io/ioutil"
-	"net/http"
 	"time"
 )
 
 const (
-	rfc3339FullDate = "2006-01-02"
-	dateFormat      = "%4d-%02d-%02d"
-	jsonFormat      = `"%4d-%02d-%02d"`
+	fullDate     = "2006-01-02"
+	fullDateJSON = `"2006-01-02"`
+	dateFormat   = "%04d-%02d-%02d"
+	jsonFormat   = `"%04d-%02d-%02d"`
 )
 
 // Date defines a type similar to time.Time but assumes a layout of RFC3339 full-date (i.e.,
@@ -28,31 +25,12 @@ type Date struct {
 
 // ParseDate create a new Date from the passed string.
 func ParseDate(date string) (d Date, err error) {
-	d = Date{}
-	d.Time, err = time.Parse(rfc3339FullDate, date)
-	return d, err
+	return parseDate(date, fullDate)
 }
 
-func readDate(r io.Reader) (Date, error) {
-	b, err := ioutil.ReadAll(r)
-	if err == nil {
-		return ParseDate(string(b))
-	}
-	return Date{}, err
-}
-
-// ByUnmarshallingDate returns a RespondDecorator that decodes the http.Response Body into a Date
-// pointed to by d.
-func ByUnmarshallingDate(d *Date) autorest.RespondDecorator {
-	return func(r autorest.Responder) autorest.Responder {
-		return autorest.ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*d, err = readDate(resp.Body)
-			}
-			return err
-		})
-	}
+func parseDate(date string, format string) (Date, error) {
+	d, err := time.Parse(format, date)
+	return Date{Time: d}, err
 }
 
 // MarshalBinary preserves the Date as a byte array conforming to RFC3339 full-date (i.e.,
@@ -76,14 +54,8 @@ func (d Date) MarshalJSON() (json []byte, err error) {
 // UnmarshalJSON reconstitutes the Date from a JSON string conforming to RFC3339 full-date (i.e.,
 // 2006-01-02).
 func (d *Date) UnmarshalJSON(data []byte) (err error) {
-	if data[0] == '"' {
-		data = data[1 : len(data)-1]
-	}
-	d.Time, err = time.Parse(rfc3339FullDate, string(data))
-	if err != nil {
-		return err
-	}
-	return nil
+	d.Time, err = time.Parse(fullDateJSON, string(data))
+	return err
 }
 
 // MarshalText preserves the Date as a byte array conforming to RFC3339 full-date (i.e.,
@@ -95,11 +67,8 @@ func (d Date) MarshalText() (text []byte, err error) {
 // UnmarshalText reconstitutes a Date saved as a byte array conforming to RFC3339 full-date (i.e.,
 // 2006-01-02).
 func (d *Date) UnmarshalText(data []byte) (err error) {
-	d.Time, err = time.Parse(rfc3339FullDate, string(data))
-	if err != nil {
-		return err
-	}
-	return nil
+	d.Time, err = time.Parse(fullDate, string(data))
+	return err
 }
 
 // String returns the Date formatted as an RFC3339 full-date string (i.e., 2006-01-02).

--- a/vendor/github.com/Azure/go-autorest/autorest/date/time.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/time.go
@@ -1,11 +1,12 @@
 package date
 
 import (
-	"github.com/Azure/go-autorest/autorest"
-	"io"
-	"io/ioutil"
-	"net/http"
 	"time"
+)
+
+const (
+	rfc3339JSON = `"` + time.RFC3339Nano + `"`
+	rfc3339     = time.RFC3339Nano
 )
 
 // Time defines a type similar to time.Time but assumes a layout of RFC3339 date-time (i.e.,
@@ -14,76 +15,49 @@ type Time struct {
 	time.Time
 }
 
-// ParseTime creates a new Time from the passed string.
-func ParseTime(date string) (d Time, err error) {
-	d = Time{}
-	d.Time, err = time.Parse(time.RFC3339, date)
-	return d, err
-}
-
-func readTime(r io.Reader) (Time, error) {
-	b, err := ioutil.ReadAll(r)
-	if err == nil {
-		return ParseTime(string(b))
-	}
-	return Time{}, err
-}
-
-// ByUnmarshallingTime returns a RespondDecorator that decodes the http.Response Body into a Time
-// pointed to by t.
-func ByUnmarshallingTime(t *Time) autorest.RespondDecorator {
-	return func(r autorest.Responder) autorest.Responder {
-		return autorest.ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*t, err = readTime(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
 // MarshalBinary preserves the Time as a byte array conforming to RFC3339 date-time (i.e.,
 // 2006-01-02T15:04:05Z).
-func (d Time) MarshalBinary() ([]byte, error) {
-	return d.Time.MarshalText()
+func (t Time) MarshalBinary() ([]byte, error) {
+	return t.Time.MarshalText()
 }
 
 // UnmarshalBinary reconstitutes a Time saved as a byte array conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
-func (d *Time) UnmarshalBinary(data []byte) error {
-	return d.Time.UnmarshalText(data)
+func (t *Time) UnmarshalBinary(data []byte) error {
+	return t.UnmarshalText(data)
 }
 
 // MarshalJSON preserves the Time as a JSON string conforming to RFC3339 date-time (i.e.,
 // 2006-01-02T15:04:05Z).
-func (d Time) MarshalJSON() (json []byte, err error) {
-	return d.Time.MarshalJSON()
+func (t Time) MarshalJSON() (json []byte, err error) {
+	return t.Time.MarshalJSON()
 }
 
 // UnmarshalJSON reconstitutes the Time from a JSON string conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
-func (d *Time) UnmarshalJSON(data []byte) (err error) {
-	return d.Time.UnmarshalJSON(data)
+func (t *Time) UnmarshalJSON(data []byte) (err error) {
+	t.Time, err = ParseTime(rfc3339JSON, string(data))
+	return err
 }
 
 // MarshalText preserves the Time as a byte array conforming to RFC3339 date-time (i.e.,
 // 2006-01-02T15:04:05Z).
-func (d Time) MarshalText() (text []byte, err error) {
-	return d.Time.MarshalText()
+func (t Time) MarshalText() (text []byte, err error) {
+	return t.Time.MarshalText()
 }
 
 // UnmarshalText reconstitutes a Time saved as a byte array conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
-func (d *Time) UnmarshalText(data []byte) (err error) {
-	return d.Time.UnmarshalText(data)
+func (t *Time) UnmarshalText(data []byte) (err error) {
+	t.Time, err = ParseTime(rfc3339, string(data))
+	return err
 }
 
 // String returns the Time formatted as an RFC3339 date-time string (i.e.,
 // 2006-01-02T15:04:05Z).
-func (d Time) String() string {
+func (t Time) String() string {
 	// Note: time.Time.String does not return an RFC3339 compliant string, time.Time.MarshalText does.
-	b, err := d.Time.MarshalText()
+	b, err := t.MarshalText()
 	if err != nil {
 		return ""
 	}
@@ -91,6 +65,6 @@ func (d Time) String() string {
 }
 
 // ToTime returns a Time as a time.Time
-func (d Time) ToTime() time.Time {
-	return d.Time
+func (t Time) ToTime() time.Time {
+	return t.Time
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/date/timerfc1123.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/timerfc1123.go
@@ -1,0 +1,86 @@
+package date
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	rfc1123JSON = `"` + time.RFC1123 + `"`
+	rfc1123     = time.RFC1123
+)
+
+// TimeRFC1123 defines a type similar to time.Time but assumes a layout of RFC1123 date-time (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+type TimeRFC1123 struct {
+	time.Time
+}
+
+// UnmarshalJSON reconstitutes the Time from a JSON string conforming to RFC1123 date-time
+// (i.e., Mon, 02 Jan 2006 15:04:05 MST).
+func (t *TimeRFC1123) UnmarshalJSON(data []byte) (err error) {
+	t.Time, err = ParseTime(rfc1123JSON, string(data))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON preserves the Time as a JSON string conforming to RFC1123 date-time (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+func (t TimeRFC1123) MarshalJSON() ([]byte, error) {
+	if y := t.Year(); y < 0 || y >= 10000 {
+		return nil, errors.New("Time.MarshalJSON: year outside of range [0,9999]")
+	}
+	b := []byte(t.Format(rfc1123JSON))
+	return b, nil
+}
+
+// MarshalText preserves the Time as a byte array conforming to RFC1123 date-time (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+func (t TimeRFC1123) MarshalText() ([]byte, error) {
+	if y := t.Year(); y < 0 || y >= 10000 {
+		return nil, errors.New("Time.MarshalText: year outside of range [0,9999]")
+	}
+
+	b := []byte(t.Format(rfc1123))
+	return b, nil
+}
+
+// UnmarshalText reconstitutes a Time saved as a byte array conforming to RFC1123 date-time
+// (i.e., Mon, 02 Jan 2006 15:04:05 MST).
+func (t *TimeRFC1123) UnmarshalText(data []byte) (err error) {
+	t.Time, err = ParseTime(rfc1123, string(data))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalBinary preserves the Time as a byte array conforming to RFC1123 date-time (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+func (t TimeRFC1123) MarshalBinary() ([]byte, error) {
+	return t.MarshalText()
+}
+
+// UnmarshalBinary reconstitutes a Time saved as a byte array conforming to RFC1123 date-time
+// (i.e., Mon, 02 Jan 2006 15:04:05 MST).
+func (t *TimeRFC1123) UnmarshalBinary(data []byte) error {
+	return t.UnmarshalText(data)
+}
+
+// ToTime returns a Time as a time.Time
+func (t TimeRFC1123) ToTime() time.Time {
+	return t.Time
+}
+
+// String returns the Time formatted as an RFC1123 date-time string (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+func (t TimeRFC1123) String() string {
+	// Note: time.Time.String does not return an RFC1123 compliant string, time.Time.MarshalText does.
+	b, err := t.MarshalText()
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/date/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/utility.go
@@ -1,0 +1,11 @@
+package date
+
+import (
+	"strings"
+	"time"
+)
+
+// ParseTime to parse Time string to specified format.
+func ParseTime(format string, t string) (d time.Time, err error) {
+	return time.Parse(format, strings.ToUpper(t))
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/preparer.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/preparer.go
@@ -195,6 +195,51 @@ func WithFormData(v url.Values) PrepareDecorator {
 	}
 }
 
+// WithBool returns a PrepareDecorator that encodes the passed bool into the body of the request
+// and sets the Content-Length header.
+func WithBool(v bool) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithFloat32 returns a PrepareDecorator that encodes the passed float32 into the body of the
+// request and sets the Content-Length header.
+func WithFloat32(v float32) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithFloat64 returns a PrepareDecorator that encodes the passed float64 into the body of the
+// request and sets the Content-Length header.
+func WithFloat64(v float64) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithInt32 returns a PrepareDecorator that encodes the passed int32 into the body of the request
+// and sets the Content-Length header.
+func WithInt32(v int32) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithInt64 returns a PrepareDecorator that encodes the passed int64 into the body of the request
+// and sets the Content-Length header.
+func WithInt64(v int64) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithString returns a PrepareDecorator that encodes the passed string into the body of the request
+// and sets the Content-Length header.
+func WithString(v string) PrepareDecorator {
+	return func(p Preparer) Preparer {
+		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err == nil {
+				r.ContentLength = int64(len(v))
+				r.Body = ioutil.NopCloser(strings.NewReader(v))
+			}
+			return r, err
+		})
+	}
+}
+
 // WithJSON returns a PrepareDecorator that encodes the data passed as JSON into the body of the
 // request and sets the Content-Length header.
 func WithJSON(v interface{}) PrepareDecorator {

--- a/vendor/github.com/Azure/go-autorest/autorest/responder.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/responder.go
@@ -1,8 +1,13 @@
 package autorest
 
 import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // Responder is the interface that wraps the Respond method.
@@ -68,6 +73,20 @@ func ByIgnoring() RespondDecorator {
 	}
 }
 
+// ByCopying copies the contents of the http.Response Body into the passed bytes.Buffer as
+// the Body is read.
+func ByCopying(b *bytes.Buffer) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil && resp != nil && resp.Body != nil {
+				resp.Body = TeeReadCloser(resp.Body, b)
+			}
+			return err
+		})
+	}
+}
+
 // ByClosing returns a RespondDecorator that first invokes the passed Responder after which it
 // closes the response body. Since the passed Responder is invoked prior to closing the response
 // body, the decorator may occur anywhere within the set.
@@ -97,116 +116,48 @@ func ByClosingIfError() RespondDecorator {
 	}
 }
 
-// ByUnmarshallingBool returns a RespondDecorator that decodes the http.Response Body into a bool
-// pointed to by b.
-func ByUnmarshallingBool(b *bool) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*b, err = readBool(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingFloat32 returns a RespondDecorator that decodes the http.Response Body into a
-// float32 pointed to by f.
-func ByUnmarshallingFloat32(f *float32) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*f, err = readFloat32(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingFloat64 returns a RespondDecorator that decodes the http.Response Body into a
-// float64 pointed to by f.
-func ByUnmarshallingFloat64(f *float64) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*f, err = readFloat64(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingInt32 returns a RespondDecorator that decodes the http.Response Body into an
-// int32 pointed to by i.
-func ByUnmarshallingInt32(i *int32) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*i, err = readInt32(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingInt64 returns a RespondDecorator that decodes the http.Response Body into an
-// int64 pointed to by i.
-func ByUnmarshallingInt64(i *int64) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*i, err = readInt64(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingString returns a RespondDecorator that decodes the http.Response Body into a
-// string pointed to by s.
-func ByUnmarshallingString(s *string) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*s, err = readString(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
 // ByUnmarshallingJSON returns a RespondDecorator that decodes a JSON document returned in the
 // response Body into the value pointed to by v.
 func ByUnmarshallingJSON(v interface{}) RespondDecorator {
-	return byUnmarshallingAs(EncodedAsJSON, v)
-}
-
-// ByUnmarshallingXML returns a RespondDecorator that decodes a XML document returned in the
-// response Body into the value pointed to by v.
-func ByUnmarshallingXML(v interface{}) RespondDecorator {
-	return byUnmarshallingAs(EncodedAsXML, v)
-}
-
-func byUnmarshallingAs(encodedAs EncodedAs, v interface{}) RespondDecorator {
 	return func(r Responder) Responder {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if err == nil {
-				b, errDecode := CopyAndDecode(encodedAs, resp.Body, v)
-				if errDecode != nil {
-					err = fmt.Errorf("Error (%v) occurred decoding %s (\"%s\")", errDecode, encodedAs, b.String())
+				b, errInner := ioutil.ReadAll(resp.Body)
+				if errInner != nil {
+					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
+				} else if len(strings.Trim(string(b), " ")) > 0 {
+					errInner = json.Unmarshal(b, v)
+					if errInner != nil {
+						err = fmt.Errorf("Error occurred unmarshalling JSON - Error = '%v' JSON = '%s'", errInner, string(b))
+					}
 				}
 			}
 			return err
 		})
 	}
+}
 
+// ByUnmarshallingXML returns a RespondDecorator that decodes a XML document returned in the
+// response Body into the value pointed to by v.
+func ByUnmarshallingXML(v interface{}) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				b, errInner := ioutil.ReadAll(resp.Body)
+				if errInner != nil {
+					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
+				} else {
+					errInner = xml.Unmarshal(b, v)
+					if errInner != nil {
+						err = fmt.Errorf("Error occurred unmarshalling Xml - Error = '%v' Xml = '%s'", errInner, string(b))
+					}
+				}
+			}
+			return err
+		})
+	}
 }
 
 // WithErrorUnlessStatusCode returns a RespondDecorator that emits an error unless the response

--- a/vendor/github.com/Azure/go-autorest/autorest/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/utility.go
@@ -6,9 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
-	"strconv"
 )
 
 // EncodedAs is a series of constants specifying various data encodings
@@ -48,53 +46,24 @@ func CopyAndDecode(encodedAs EncodedAs, r io.Reader, v interface{}) (bytes.Buffe
 	return b, NewDecoder(encodedAs, io.TeeReader(r, &b)).Decode(v)
 }
 
-func readBool(r io.Reader) (bool, error) {
-	s, err := readString(r)
-	if err == nil {
-		return strconv.ParseBool(s)
-	}
-	return false, err
+// TeeReadCloser returns a ReadCloser that writes to w what it reads from rc.
+// It utilizes io.TeeReader to copy the data read and has the same behavior when reading.
+// Further, when it is closed, it ensures that rc is closed as well.
+func TeeReadCloser(rc io.ReadCloser, w io.Writer) io.ReadCloser {
+	return &teeReadCloser{rc, io.TeeReader(rc, w)}
 }
 
-func readFloat32(r io.Reader) (float32, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseFloat(s, 32)
-		return float32(v), err
-	}
-	return float32(0), err
+type teeReadCloser struct {
+	rc io.ReadCloser
+	r  io.Reader
 }
 
-func readFloat64(r io.Reader) (float64, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseFloat(s, 64)
-		return v, err
-	}
-	return float64(0), err
+func (t *teeReadCloser) Read(p []byte) (int, error) {
+	return t.r.Read(p)
 }
 
-func readInt32(r io.Reader) (int32, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseInt(s, 10, 32)
-		return int32(v), err
-	}
-	return int32(0), err
-}
-
-func readInt64(r io.Reader) (int64, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseInt(s, 10, 64)
-		return v, err
-	}
-	return int64(0), err
-}
-
-func readString(r io.Reader) (string, error) {
-	b, err := ioutil.ReadAll(r)
-	return string(b), err
+func (t *teeReadCloser) Close() error {
+	return t.rc.Close()
 }
 
 func containsInt(ints []int, n int) bool {

--- a/vendor/github.com/Azure/go-autorest/autorest/version.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	major        = "5"
+	major        = "7"
 	minor        = "0"
 	patch        = "0"
 	tag          = ""


### PR DESCRIPTION
Update to latest azure-sdk-for-go.

SDK fixes the polling issue when deleting the resource group, so I got to
remove a hack.

A cancel channel is now exposed whereever there's a long running
operation.  The channel is closed to signal the SDK to cancel polling
operations, not to cancel the operation.
  
