### PR TITLE
Output a reasonable artifact.

### DIFF
--- a/packer/builder/azure/arm/artifact.go
+++ b/packer/builder/azure/arm/artifact.go
@@ -3,34 +3,110 @@
 
 package arm
 
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
 const (
 	BuilderId = "Azure.ResourceManagement.VMImage"
 )
 
-type artifact struct {
-	name string
+type Artifact struct {
+	StorageAccountLocation string
+	OSDiskUri              string
+	TemplateUri            string
+	OSDiskUriReadOnlySas   string
+	TemplateUriReadOnlySas string
 }
 
-func (*artifact) BuilderId() string {
+func NewArtifact(template *CaptureTemplate, getSasUrl func(name string) string) (*Artifact, error) {
+	if template == nil {
+		return nil, fmt.Errorf("nil capture template")
+	}
+
+	if len(template.Resources) != 1 {
+		return nil, fmt.Errorf("malformed capture template, expected one resource")
+	}
+
+	vhdUri, err := url.Parse(template.Resources[0].Properties.StorageProfile.OSDisk.Image.Uri)
+	if err != nil {
+		return nil, err
+	}
+
+	templateUri, err := storageUriToTemplateUri(vhdUri)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Artifact{
+		OSDiskUri:              vhdUri.String(),
+		OSDiskUriReadOnlySas:   getSasUrl(getStorageUrlPath(vhdUri)),
+		TemplateUri:            templateUri.String(),
+		TemplateUriReadOnlySas: getSasUrl(getStorageUrlPath(templateUri)),
+
+		StorageAccountLocation: template.Resources[0].Location,
+	}, nil
+}
+
+func getStorageUrlPath(u *url.URL) string {
+	parts := strings.Split(u.Path, "/")
+	return strings.Join(parts[3:], "/")
+}
+
+func storageUriToTemplateUri(su *url.URL) (*url.URL, error) {
+	// packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd -> 4085bb15-3644-4641-b9cd-f575918640b4
+	filename := path.Base(su.Path)
+	parts := strings.Split(filename, ".")
+
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("malformed URL")
+	}
+
+	// packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd -> packer
+	prefixParts := strings.Split(parts[0], "-")
+	prefix := strings.Join(prefixParts[:len(prefixParts)-1], "-")
+
+	templateFilename := fmt.Sprintf("%s-vmTemplate.%s.json", prefix, parts[1])
+
+	// https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd"
+	//   ->
+	// https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json"
+	return url.Parse(strings.Replace(su.String(), filename, templateFilename, 1))
+}
+
+func (*Artifact) BuilderId() string {
 	return BuilderId
 }
 
-func (*artifact) Files() []string {
+func (*Artifact) Files() []string {
 	return []string{}
 }
 
-func (*artifact) Id() string {
+func (*Artifact) Id() string {
 	return ""
 }
 
-func (*artifact) State(name string) interface{} {
+func (*Artifact) State(name string) interface{} {
 	return nil
 }
 
-func (*artifact) String() string {
-	return "{}"
+func (a *Artifact) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(fmt.Sprintf("%s:\n\n", a.BuilderId()))
+	buf.WriteString(fmt.Sprintf("StorageAccountLocation: %s\n", a.StorageAccountLocation))
+	buf.WriteString(fmt.Sprintf("OSDiskUri: %s\n", a.OSDiskUri))
+	buf.WriteString(fmt.Sprintf("OSDiskUriReadOnlySas: %s\n", a.OSDiskUriReadOnlySas))
+	buf.WriteString(fmt.Sprintf("TemplateUri: %s\n", a.TemplateUri))
+	buf.WriteString(fmt.Sprintf("TemplateUriReadOnlySas: %s\n", a.TemplateUriReadOnlySas))
+
+	return buf.String()
 }
 
-func (*artifact) Destroy() error {
+func (*Artifact) Destroy() error {
 	return nil
 }

--- a/packer/builder/azure/arm/artifact_test.go
+++ b/packer/builder/azure/arm/artifact_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package arm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func getFakeSasUrl(name string) string {
+	return fmt.Sprintf("SAS-%s", name)
+}
+
+func TestArtifactString(t *testing.T) {
+	template := CaptureTemplate{
+		Resources: []CaptureResources{
+			CaptureResources{
+				Properties: CaptureProperties{
+					StorageProfile: CaptureStorageProfile{
+						OSDisk: CaptureDisk{
+							Image: CaptureUri{
+								Uri: "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd",
+							},
+						},
+					},
+				},
+				Location: "southcentralus",
+			},
+		},
+	}
+
+	artifact, err := NewArtifact(&template, getFakeSasUrl)
+	if err != nil {
+		t.Fatalf("err=%s", err)
+	}
+
+	testSubject := artifact.String()
+	if !strings.Contains(testSubject, "OSDiskUri: https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd") {
+		t.Errorf("Expected String() output to contain OSDiskUri")
+	}
+	if !strings.Contains(testSubject, "OSDiskUriReadOnlySas: SAS-Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd") {
+		t.Errorf("Expected String() output to contain OSDiskUriReadOnlySas")
+	}
+	if !strings.Contains(testSubject, "TemplateUri: https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json") {
+		t.Errorf("Expected String() output to contain TemplateUri")
+	}
+	if !strings.Contains(testSubject, "TemplateUriReadOnlySas: SAS-Images/images/packer-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json") {
+		t.Errorf("Expected String() output to contain TemplateUriReadOnlySas")
+	}
+	if !strings.Contains(testSubject, "StorageAccountLocation: southcentralus") {
+		t.Errorf("Expected String() output to contain StorageAccountLocation")
+	}
+}
+
+func TestArtifactProperties(t *testing.T) {
+	template := CaptureTemplate{
+		Resources: []CaptureResources{
+			CaptureResources{
+				Properties: CaptureProperties{
+					StorageProfile: CaptureStorageProfile{
+						OSDisk: CaptureDisk{
+							Image: CaptureUri{
+								Uri: "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd",
+							},
+						},
+					},
+				},
+				Location: "southcentralus",
+			},
+		},
+	}
+
+	testSubject, err := NewArtifact(&template, getFakeSasUrl)
+	if err != nil {
+		t.Fatalf("err=%s", err)
+	}
+
+	if testSubject.OSDiskUri != "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd" {
+		t.Errorf("Expected template to be 'https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd', but got %s", testSubject.OSDiskUri)
+	}
+	if testSubject.OSDiskUriReadOnlySas != "SAS-Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd" {
+		t.Errorf("Expected template to be 'SAS-Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd', but got %s", testSubject.OSDiskUriReadOnlySas)
+	}
+	if testSubject.TemplateUri != "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json" {
+		t.Errorf("Expected template to be 'https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json', but got %s", testSubject.TemplateUri)
+	}
+	if testSubject.TemplateUriReadOnlySas != "SAS-Images/images/packer-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json" {
+		t.Errorf("Expected template to be 'SAS-Images/images/packer-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json', but got %s", testSubject.TemplateUriReadOnlySas)
+	}
+	if testSubject.StorageAccountLocation != "southcentralus" {
+		t.Errorf("Expected StorageAccountLocation to be 'southcentral', but got %s", testSubject.StorageAccountLocation)
+	}
+}
+
+func TestArtifactOverHypenatedCaptureUri(t *testing.T) {
+	template := CaptureTemplate{
+		Resources: []CaptureResources{
+			CaptureResources{
+				Properties: CaptureProperties{
+					StorageProfile: CaptureStorageProfile{
+						OSDisk: CaptureDisk{
+							Image: CaptureUri{
+								Uri: "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/pac-ker-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd",
+							},
+						},
+					},
+				},
+				Location: "southcentralus",
+			},
+		},
+	}
+
+	testSubject, err := NewArtifact(&template, getFakeSasUrl)
+	if err != nil {
+		t.Fatalf("err=%s", err)
+	}
+
+	if testSubject.TemplateUri != "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/pac-ker-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json" {
+		t.Errorf("Expected template to be 'https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/pac-ker-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json', but got %s", testSubject.TemplateUri)
+	}
+}
+
+func TestArtifactRejectMalformedTemplates(t *testing.T) {
+	template := CaptureTemplate{}
+
+	_, err := NewArtifact(&template, getFakeSasUrl)
+	if err == nil {
+		t.Fatalf("Expected artifact creation to fail, but it succeeded.")
+	}
+}
+
+func TestArtifactRejectMalformedStorageUri(t *testing.T) {
+	template := CaptureTemplate{
+		Resources: []CaptureResources{
+			CaptureResources{
+				Properties: CaptureProperties{
+					StorageProfile: CaptureStorageProfile{
+						OSDisk: CaptureDisk{
+							Image: CaptureUri{
+								Uri: "bark",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := NewArtifact(&template, getFakeSasUrl)
+	if err == nil {
+		t.Fatalf("Expected artifact creation to fail, but it succeeded.")
+	}
+}

--- a/packer/builder/azure/arm/capture_template.go
+++ b/packer/builder/azure/arm/capture_template.go
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package arm
+
+type CaptureTemplateParameter struct {
+	Type         string `json:"type"`
+	DefaultValue string `json:"defaultValue,omitempty"`
+}
+
+type CaptureHardwareProfile struct {
+	VMSize string `json:"vmSize"`
+}
+
+type CaptureUri struct {
+	Uri string `json:"uri"`
+}
+
+type CaptureDisk struct {
+	OSType       string     `json:"osType"`
+	Name         string     `json:"name"`
+	Image        CaptureUri `json:"image"`
+	Vhd          CaptureUri `json:"vhd"`
+	CreateOption string     `json:"createOption"`
+	Caching      string     `json:"caching"`
+}
+
+type CaptureStorageProfile struct {
+	OSDisk CaptureDisk `json:"osDisk"`
+}
+
+type CaptureOSProfile struct {
+	ComputerName  string `json:"computerName"`
+	AdminUsername string `json:"adminUsername"`
+	AdminPassword string `json:"adminPassword"`
+}
+
+type CaptureNetworkInterface struct {
+	Id string `json:"id"`
+}
+
+type CaptureNetworkProfile struct {
+	NetworkInterfaces []CaptureNetworkInterface `json:"networkInterfaces"`
+}
+
+type CaptureBootDiagnostics struct {
+	Enabled bool `json:"enabled"`
+}
+
+type CaptureDiagnosticProfile struct {
+	BootDiagnostics CaptureBootDiagnostics `json:"bootDiagnostics"`
+}
+
+type CaptureProperties struct {
+	HardwareProfile    CaptureHardwareProfile   `json:"hardwareProfile"`
+	StorageProfile     CaptureStorageProfile    `json:"storageProfile"`
+	OSProfile          CaptureOSProfile         `json:"osProfile"`
+	NetworkProfile     CaptureNetworkProfile    `json:"networkProfile"`
+	DiagnosticsProfile CaptureDiagnosticProfile `json:"diagnosticsProfile"`
+	ProvisioningState  int                      `json:"provisioningState"`
+}
+
+type CaptureResources struct {
+	ApiVersion string            `json:"apiVersion"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Properties CaptureProperties `json:"properties"`
+}
+
+type CaptureTemplate struct {
+	Schema         string                              `json:"$schema"`
+	ContentVersion string                              `json:"contentVersion"`
+	Parameters     map[string]CaptureTemplateParameter `json:"parameters"`
+	Resources      []CaptureResources                  `json:"resources"`
+}
+
+type CaptureOperationProperties struct {
+	Output *CaptureTemplate `json:"output"`
+}
+
+type CaptureOperation struct {
+	OperationId string                      `json:"operationId"`
+	Status      string                      `json:"status"`
+	Properties  *CaptureOperationProperties `json:"properties"`
+}

--- a/packer/builder/azure/arm/capture_template_test.go
+++ b/packer/builder/azure/arm/capture_template_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+
+package arm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var captureTemplate01 = `{
+    "operationId": "ac1c7c38-a591-41b3-89bd-ea39fceace1b",
+    "status": "Succeeded",
+    "startTime": "2016-04-04T21:07:25.2900874+00:00",
+    "endTime": "2016-04-04T21:07:26.4776321+00:00",
+    "properties": {
+        "output": {
+            "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/VM_IP.json",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+                "vmName": {
+                    "type": "string"
+                },
+                "vmSize": {
+                    "type": "string",
+                    "defaultValue": "Standard_A2"
+                },
+                "adminUserName": {
+                    "type": "string"
+                },
+                "adminPassword": {
+                    "type": "securestring"
+                },
+                "networkInterfaceId": {
+                    "type": "string"
+                }
+            },
+            "resources": [
+                {
+                    "apiVersion": "2015-06-15",
+                    "properties": {
+                        "hardwareProfile": {
+                            "vmSize": "[parameters('vmSize')]"
+                        },
+                        "storageProfile": {
+                            "osDisk": {
+                                "osType": "Linux",
+                                "name": "packer-osDisk.32118633-6dc9-449f-83b6-a7d2983bec14.vhd",
+                                "createOption": "FromImage",
+                                "image": {
+                                    "uri": "http://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.32118633-6dc9-449f-83b6-a7d2983bec14.vhd"
+                                },
+                                "vhd": {
+                                    "uri": "http://storage.blob.core.windows.net/vmcontainerce1a1b75-f480-47cb-8e6e-55142e4a5f68/osDisk.ce1a1b75-f480-47cb-8e6e-55142e4a5f68.vhd"
+                                },
+                                "caching": "ReadWrite"
+                            }
+                        },
+                        "osProfile": {
+                            "computerName": "[parameters('vmName')]",
+                            "adminUsername": "[parameters('adminUsername')]",
+                            "adminPassword": "[parameters('adminPassword')]"
+                        },
+                        "networkProfile": {
+                            "networkInterfaces": [
+                                {
+                                    "id": "[parameters('networkInterfaceId')]"
+                                }
+                            ]
+                        },
+                        "diagnosticsProfile": {
+                            "bootDiagnostics": {
+                                "enabled": false
+                            }
+                        },
+                        "provisioningState": 0
+                    },
+                    "name": "[parameters('vmName')]",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "location": "southcentralus"
+                }
+            ]
+        }
+    }
+}`
+
+var captureTemplate02 = `{
+    "operationId": "ac1c7c38-a591-41b3-89bd-ea39fceace1b",
+    "status": "Succeeded",
+    "startTime": "2016-04-04T21:07:25.2900874+00:00",
+    "endTime": "2016-04-04T21:07:26.4776321+00:00"
+}`
+
+func TestCaptureParseJson(t *testing.T) {
+	var operation CaptureOperation
+	err := json.Unmarshal([]byte(captureTemplate01), &operation)
+	if err != nil {
+		t.Fatalf("failed to the sample capture operation: %s", err)
+	}
+
+	testSubject := operation.Properties.Output
+	if testSubject.Schema != "http://schema.management.azure.com/schemas/2014-04-01-preview/VM_IP.json" {
+		t.Errorf("Schema's value was unexpected: %s", testSubject.Schema)
+	}
+	if testSubject.ContentVersion != "1.0.0.0" {
+		t.Errorf("ContentVersion's value was unexpected: %s", testSubject.ContentVersion)
+	}
+
+	// == Parameters ====================================
+	if len(testSubject.Parameters) != 5 {
+		t.Fatalf("expected parameters to have 5 keys, but got %d", len(testSubject.Parameters))
+	}
+	if _, ok := testSubject.Parameters["vmName"]; !ok {
+		t.Errorf("Parameters['vmName'] was an expected parameters, but it did not exist")
+	}
+	if testSubject.Parameters["vmName"].Type != "string" {
+		t.Errorf("Parameters['vmName'].Type == 'string', but got '%s'", testSubject.Parameters["vmName"].Type)
+	}
+	if _, ok := testSubject.Parameters["vmSize"]; !ok {
+		t.Errorf("Parameters['vmSize'] was an expected parameters, but it did not exist")
+	}
+	if testSubject.Parameters["vmSize"].Type != "string" {
+		t.Errorf("Parameters['vmSize'].Type == 'string', but got '%s'", testSubject.Parameters["vmSize"])
+	}
+	if testSubject.Parameters["vmSize"].DefaultValue != "Standard_A2" {
+		t.Errorf("Parameters['vmSize'].DefaultValue == 'string', but got '%s'", testSubject.Parameters["vmSize"].DefaultValue)
+	}
+
+	// == Resources =====================================
+	if len(testSubject.Resources) != 1 {
+		t.Fatalf("expected resources to have length 1, but got %d", len(testSubject.Resources))
+	}
+	if testSubject.Resources[0].Name != "[parameters('vmName')]" {
+		t.Errorf("Resources[0].Name's value was unexpected: %s", testSubject.Resources[0].Name)
+	}
+	if testSubject.Resources[0].Type != "Microsoft.Compute/virtualMachines" {
+		t.Errorf("Resources[0].Type's value was unexpected: %s", testSubject.Resources[0].Type)
+	}
+	if testSubject.Resources[0].Location != "southcentralus" {
+		t.Errorf("Resources[0].Location's value was unexpected: %s", testSubject.Resources[0].Location)
+	}
+
+	// == Resources/Properties =====================================
+	if testSubject.Resources[0].Properties.ProvisioningState != 0 {
+		t.Errorf("Resources[0].Properties.ProvisioningState's value was unexpected: %d", testSubject.Resources[0].Properties.ProvisioningState)
+	}
+
+	// == Resources/Properties/HardwareProfile ======================
+	hardwareProfile := testSubject.Resources[0].Properties.HardwareProfile
+	if hardwareProfile.VMSize != "[parameters('vmSize')]" {
+		t.Errorf("Resources[0].Properties.HardwareProfile.VMSize's value was unexpected: %s", hardwareProfile.VMSize)
+	}
+
+	// == Resources/Properties/StorageProfile/OSDisk ================
+	osDisk := testSubject.Resources[0].Properties.StorageProfile.OSDisk
+	if osDisk.OSType != "Linux" {
+		t.Errorf("Resources[0].Properties.StorageProfile.OSDisk.OSDisk's value was unexpected: %s", osDisk.OSType)
+	}
+	if osDisk.Name != "packer-osDisk.32118633-6dc9-449f-83b6-a7d2983bec14.vhd" {
+		t.Errorf("Resources[0].Properties.StorageProfile.OSDisk.Name's value was unexpected: %s", osDisk.Name)
+	}
+	if osDisk.CreateOption != "FromImage" {
+		t.Errorf("Resources[0].Properties.StorageProfile.OSDisk.CreateOption's value was unexpected: %s", osDisk.CreateOption)
+	}
+	if osDisk.Image.Uri != "http://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.32118633-6dc9-449f-83b6-a7d2983bec14.vhd" {
+		t.Errorf("Resources[0].Properties.StorageProfile.OSDisk.Image.Uri's value was unexpected: %s", osDisk.Image.Uri)
+	}
+	if osDisk.Vhd.Uri != "http://storage.blob.core.windows.net/vmcontainerce1a1b75-f480-47cb-8e6e-55142e4a5f68/osDisk.ce1a1b75-f480-47cb-8e6e-55142e4a5f68.vhd" {
+		t.Errorf("Resources[0].Properties.StorageProfile.OSDisk.Vhd.Uri's value was unexpected: %s", osDisk.Vhd.Uri)
+	}
+	if osDisk.Caching != "ReadWrite" {
+		t.Errorf("Resources[0].Properties.StorageProfile.OSDisk.Caching's value was unexpected: %s", osDisk.Caching)
+	}
+
+	// == Resources/Properties/OSProfile ============================
+	osProfile := testSubject.Resources[0].Properties.OSProfile
+	if osProfile.AdminPassword != "[parameters('adminPassword')]" {
+		t.Errorf("Resources[0].Properties.OSProfile.AdminPassword's value was unexpected: %s", osProfile.AdminPassword)
+	}
+	if osProfile.AdminUsername != "[parameters('adminUsername')]" {
+		t.Errorf("Resources[0].Properties.OSProfile.AdminUsername's value was unexpected: %s", osProfile.AdminUsername)
+	}
+	if osProfile.ComputerName != "[parameters('vmName')]" {
+		t.Errorf("Resources[0].Properties.OSProfile.ComputerName's value was unexpected: %s", osProfile.ComputerName)
+	}
+
+	// == Resources/Properties/NetworkProfile =======================
+	networkProfile := testSubject.Resources[0].Properties.NetworkProfile
+	if len(networkProfile.NetworkInterfaces) != 1 {
+		t.Errorf("Count of Resources[0].Properties.NetworkProfile.NetworkInterfaces was expected to be 1, but go %d", len(networkProfile.NetworkInterfaces))
+	}
+	if networkProfile.NetworkInterfaces[0].Id != "[parameters('networkInterfaceId')]" {
+		t.Errorf("Resources[0].Properties.NetworkProfile.NetworkInterfaces[0].Id's value was unexpected: %s", networkProfile.NetworkInterfaces[0].Id)
+	}
+
+	// == Resources/Properties/DiagnosticsProfile ===================
+	diagnosticsProfile := testSubject.Resources[0].Properties.DiagnosticsProfile
+	if diagnosticsProfile.BootDiagnostics.Enabled != false {
+		t.Errorf("Resources[0].Properties.DiagnosticsProfile.BootDiagnostics.Enabled's value was unexpected: %t", diagnosticsProfile.BootDiagnostics.Enabled)
+	}
+}
+
+func TestCaptureEmptyOperationJson(t *testing.T) {
+	var operation CaptureOperation
+	err := json.Unmarshal([]byte(captureTemplate02), &operation)
+	if err != nil {
+		t.Fatalf("failed to the sample capture operation: %s", err)
+	}
+
+	if operation.Properties != nil {
+		t.Errorf("JSON contained no properties, but value was not nil: %+v", operation.Properties)
+	}
+}

--- a/packer/builder/azure/arm/inspector.go
+++ b/packer/builder/azure/arm/inspector.go
@@ -21,11 +21,11 @@ func chop(data []byte, maxlen int64) string {
 }
 
 func handleBody(body io.ReadCloser, maxlen int64) (io.ReadCloser, string) {
-	defer body.Close()
-
 	if body == nil {
 		return nil, ""
 	}
+
+	defer body.Close()
 
 	b, err := ioutil.ReadAll(body)
 	if err != nil {

--- a/packer/builder/azure/arm/step_capture_image_test.go
+++ b/packer/builder/azure/arm/step_capture_image_test.go
@@ -17,6 +17,9 @@ func TestStepCaptureImageShouldFailIfCaptureFails(t *testing.T) {
 		capture: func(string, string, *compute.VirtualMachineCaptureParameters, <-chan struct{}) error {
 			return fmt.Errorf("!! Unit Test FAIL !!")
 		},
+		get: func(client *AzureClient) *CaptureTemplate {
+			return nil
+		},
 		say:   func(message string) {},
 		error: func(e error) {},
 	}
@@ -36,8 +39,11 @@ func TestStepCaptureImageShouldFailIfCaptureFails(t *testing.T) {
 func TestStepCaptureImageShouldPassIfCapturePasses(t *testing.T) {
 	var testSubject = &StepCaptureImage{
 		capture: func(string, string, *compute.VirtualMachineCaptureParameters, <-chan struct{}) error { return nil },
-		say:     func(message string) {},
-		error:   func(e error) {},
+		get: func(client *AzureClient) *CaptureTemplate {
+			return nil
+		},
+		say:   func(message string) {},
+		error: func(e error) {},
 	}
 
 	stateBag := createTestStateBagStepCaptureImage()
@@ -59,6 +65,9 @@ func TestStepCaptureImageShouldTakeStepArgumentsFromStateBag(t *testing.T) {
 	var actualResourceGroupName string
 	var actualComputeName string
 	var actualVirtualMachineCaptureParameters *compute.VirtualMachineCaptureParameters
+	actualCaptureTemplate := &CaptureTemplate{
+		Schema: "!! Unit Test !!",
+	}
 
 	var testSubject = &StepCaptureImage{
 		capture: func(resourceGroupName string, computeName string, parameters *compute.VirtualMachineCaptureParameters, cancelCh <-chan struct{}) error {
@@ -67,6 +76,9 @@ func TestStepCaptureImageShouldTakeStepArgumentsFromStateBag(t *testing.T) {
 			actualVirtualMachineCaptureParameters = parameters
 
 			return nil
+		},
+		get: func(client *AzureClient) *CaptureTemplate {
+			return actualCaptureTemplate
 		},
 		say:   func(message string) {},
 		error: func(e error) {},
@@ -82,6 +94,7 @@ func TestStepCaptureImageShouldTakeStepArgumentsFromStateBag(t *testing.T) {
 	var expectedComputeName = stateBag.Get(constants.ArmComputeName).(string)
 	var expectedResourceGroupName = stateBag.Get(constants.ArmResourceGroupName).(string)
 	var expectedVirtualMachineCaptureParameters = stateBag.Get(constants.ArmVirtualMachineCaptureParameters).(*compute.VirtualMachineCaptureParameters)
+	var expectedCaptureTemplate = stateBag.Get(constants.ArmCaptureTemplate).(*CaptureTemplate)
 
 	if actualComputeName != expectedComputeName {
 		t.Fatalf("Expected StepCaptureImage to source 'constants.ArmComputeName' from the state bag, but it did not.")
@@ -93,6 +106,10 @@ func TestStepCaptureImageShouldTakeStepArgumentsFromStateBag(t *testing.T) {
 
 	if actualVirtualMachineCaptureParameters != expectedVirtualMachineCaptureParameters {
 		t.Fatalf("Expected StepCaptureImage to source 'constants.ArmVirtualMachineCaptureParameters' from the state bag, but it did not.")
+	}
+
+	if actualCaptureTemplate != expectedCaptureTemplate {
+		t.Fatalf("Expected StepCaptureImage to source 'constants.ArmCaptureTemplate' from the state bag, but it did not.")
 	}
 }
 

--- a/packer/builder/azure/common/constants/stateBag.go
+++ b/packer/builder/azure/common/constants/stateBag.go
@@ -30,6 +30,7 @@ const (
 )
 const (
 	ArmBlobEndpoint                    string = "arm.BlobEndpoint"
+	ArmCaptureTemplate                 string = "arm.CaptureTemplate"
 	ArmComputeName                     string = "arm.ComputeName"
 	ArmCertificateUrl                  string = "arm.CertificateUrl"
 	ArmDeploymentName                  string = "arm.DeploymentName"

--- a/packer/builder/azure/common/interruptible_task.go
+++ b/packer/builder/azure/common/interruptible_task.go
@@ -31,7 +31,6 @@ func StartInterruptibleTask(isCancelled func() bool, task func(cancelCh <-chan s
 
 func (s *InterruptibleTask) Run() InterruptibleTaskResult {
 	completeCh := make(chan error)
-	defer close(completeCh)
 
 	cancelCh := make(chan struct{})
 	defer close(cancelCh)
@@ -39,10 +38,10 @@ func (s *InterruptibleTask) Run() InterruptibleTaskResult {
 	go func() {
 		err := s.Task(cancelCh)
 		completeCh <- err
-	}()
 
-	resultCh := make(chan InterruptibleTaskResult)
-	defer close(resultCh)
+		// senders close, receivers check for close
+		close(completeCh)
+	}()
 
 	for {
 		if s.IsCancelled() {


### PR DESCRIPTION
The artifact now includes the following data.

 * storage account location
 * storage account blob name
 * URL of the packer VHD
 * read-only SAS URL of the packer VHD that's good for about 30 days
 * URL of a template to deploy the VHD
 * read-only SAS URL of a template to deploy the VHD that's good for about
   30 days