### PR TITLE
Create storage client during online config validation

### DIFF
--- a/packer/builder/azure/smapi/builder.go
+++ b/packer/builder/azure/smapi/builder.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Azure/packer-azure/packer/builder/azure/common/constants"
 	"github.com/Azure/packer-azure/packer/builder/azure/common/lin"
-	"github.com/Azure/packer-azure/packer/builder/azure/smapi/win"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/helper/communicator"
@@ -130,7 +129,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				TmpVmName:      b.config.tmpVmName,
 				OSType:         b.config.OSType,
 			},
-			&win.StepSetProvisionInfrastructure{
+			&StepSetProvisionInfrastructure{
 				VmName:                    b.config.tmpVmName,
 				ServiceName:               b.config.tmpServiceName,
 				StorageAccountName:        b.config.StorageAccount,

--- a/packer/builder/azure/smapi/config.go
+++ b/packer/builder/azure/smapi/config.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/storage"
 	azureCommon "github.com/Azure/packer-azure/packer/builder/azure/common"
 	"github.com/Azure/packer-azure/packer/builder/azure/common/constants"
 	"github.com/mitchellh/packer/common"
@@ -22,12 +23,14 @@ type Config struct {
 	SubscriptionName    string `mapstructure:"subscription_name"`
 	PublishSettingsPath string `mapstructure:"publish_settings_path"`
 
-	StorageAccount   string        `mapstructure:"storage_account"`
-	StorageContainer string        `mapstructure:"storage_account_container"`
-	Location         string        `mapstructure:"location"`
-	InstanceSize     string        `mapstructure:"instance_size"`
-	DataDisks        []interface{} `mapstructure:"data_disks"`
-	UserImageLabel   string        `mapstructure:"user_image_label"`
+	StorageAccount    string `mapstructure:"storage_account"`
+	storageAccountKey string
+	storageClient     storage.Client
+	StorageContainer  string        `mapstructure:"storage_account_container"`
+	Location          string        `mapstructure:"location"`
+	InstanceSize      string        `mapstructure:"instance_size"`
+	DataDisks         []interface{} `mapstructure:"data_disks"`
+	UserImageLabel    string        `mapstructure:"user_image_label"`
 
 	OSType                string `mapstructure:"os_type"`
 	OSImageLabel          string `mapstructure:"os_image_label"`

--- a/packer/builder/azure/smapi/step_set_provision_infrastructure.go
+++ b/packer/builder/azure/smapi/step_set_provision_infrastructure.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See the LICENSE file in the project root for license information.
 
-package win
+package azure
 
 import (
 	"fmt"
@@ -13,7 +13,6 @@ import (
 	"github.com/mitchellh/packer/packer"
 
 	"github.com/Azure/azure-sdk-for-go/management"
-	"github.com/Azure/azure-sdk-for-go/management/storageservice"
 	"github.com/Azure/azure-sdk-for-go/storage"
 )
 
@@ -24,42 +23,25 @@ type StepSetProvisionInfrastructure struct {
 	TempContainerName         string
 	ProvisionTimeoutInMinutes uint
 
-	storageClient            storage.Client
 	flagTempContainerCreated bool
 }
 
 func (s *StepSetProvisionInfrastructure) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	client := state.Get(constants.RequestManager).(management.Client)
+	config := state.Get(constants.Config).(*Config)
 
-	errorMsg := "Error StepRemoteSession: %s"
+	errorMsg := "Error StepSetProvisionInfrastructure: %s"
 	ui.Say("Preparing infrastructure for provision...")
 
 	// get key for storage account
-	ui.Message("Getting key for storage account...")
-
-	keys, err := storageservice.NewClient(client).GetStorageServiceKeys(s.StorageAccountName)
-	if err != nil {
-		err := fmt.Errorf(errorMsg, err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
-
-	//create storage driver
-	s.storageClient, err = storage.NewBasicClient(s.StorageAccountName, keys.PrimaryKey)
-	if err != nil {
-		err := fmt.Errorf(errorMsg, err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
+	ui.Message("Looking up storage account...")
 
 	//create temporary container
 	s.flagTempContainerCreated = false
 
 	ui.Message("Creating Azure temporary container...")
-	err = s.storageClient.GetBlobService().CreateContainer(s.TempContainerName, storage.ContainerAccessTypePrivate)
+	err := config.storageClient.GetBlobService().CreateContainer(s.TempContainerName, storage.ContainerAccessTypePrivate)
 	if err != nil {
 		err := fmt.Errorf(errorMsg, err)
 		state.Put("error", err)
@@ -69,24 +51,18 @@ func (s *StepSetProvisionInfrastructure) Run(state multistep.StateBag) multistep
 
 	s.flagTempContainerCreated = true
 
-	comm, err := azureVmCustomScriptExtension.New(
+	comm := azureVmCustomScriptExtension.New(
 		azureVmCustomScriptExtension.Config{
 			ServiceName:               s.ServiceName,
 			VmName:                    s.VmName,
 			StorageAccountName:        s.StorageAccountName,
-			StorageAccountKey:         keys.PrimaryKey,
+			StorageAccountKey:         config.storageAccountKey,
+			BlobClient:                config.storageClient.GetBlobService(),
 			ContainerName:             s.TempContainerName,
 			Ui:                        ui,
 			ManagementClient:          client,
 			ProvisionTimeoutInMinutes: s.ProvisionTimeoutInMinutes,
 		})
-
-	if err != nil {
-		err := fmt.Errorf(errorMsg, err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
 
 	packerCommunicator := packer.Communicator(comm)
 
@@ -97,12 +73,13 @@ func (s *StepSetProvisionInfrastructure) Run(state multistep.StateBag) multistep
 
 func (s *StepSetProvisionInfrastructure) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packer.Ui)
+	config := state.Get(constants.Config).(*Config)
 	ui.Say("Cleaning Up Infrastructure for provision...")
 
 	if s.flagTempContainerCreated {
 		ui.Message("Removing Azure temporary container...")
 
-		err := s.storageClient.GetBlobService().DeleteContainer(s.TempContainerName)
+		err := config.storageClient.GetBlobService().DeleteContainer(s.TempContainerName)
 		if err != nil {
 			ui.Message("Error removing temporary container: " + err.Error())
 		}

--- a/packer/communicator/azureVmCustomScriptExtension/communicator.go
+++ b/packer/communicator/azureVmCustomScriptExtension/communicator.go
@@ -38,25 +38,17 @@ type Config struct {
 	VmName                    string
 	StorageAccountName        string
 	StorageAccountKey         string
+	BlobClient                storage.BlobStorageClient
 	ContainerName             string
 	Ui                        packer.Ui
 	ProvisionTimeoutInMinutes uint
 	ManagementClient          management.Client
-
-	blobClient storage.BlobStorageClient
 }
 
-func New(config Config) (result *comm, err error) {
-	storageClient, err := storage.NewBasicClient(config.StorageAccountName, config.StorageAccountKey)
-	if err != nil {
-		return nil, err
-	}
-	config.blobClient = storageClient.GetBlobService()
-
-	result = &comm{
+func New(config Config) (result *comm) {
+	return &comm{
 		config: config,
 	}
-	return
 }
 
 func (c *comm) Start(cmd *packer.RemoteCmd) (err error) {
@@ -431,7 +423,7 @@ func (c *comm) uploadFile(dscPath string, srcPath string) error {
 	}
 
 	ui := c.config.Ui
-	sa := c.config.blobClient
+	sa := c.config.BlobClient
 
 	containerName := c.config.ContainerName
 


### PR DESCRIPTION
… and use it everywhere.
Non-public cloud provisioning for Windows machines was broken because in two places storage clients were being created with default base uri (core.windows.net).

cc: @boumenot @mbearup 